### PR TITLE
fix: Scope down cluster-admin for openclaw service account

### DIFF
--- a/k8s/apps/openclaw/rbac.yaml
+++ b/k8s/apps/openclaw/rbac.yaml
@@ -8,16 +8,59 @@ metadata:
     app.kubernetes.io/instance: openclaw
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
-  name: openclaw-cluster-admin
+  name: openclaw-editor
+  namespace: openclaw
+  labels:
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/instance: openclaw
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - configmaps
+      - secrets
+      - serviceaccounts
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openclaw-editor-binding
+  namespace: openclaw
   labels:
     app.kubernetes.io/name: openclaw
     app.kubernetes.io/instance: openclaw
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
+  kind: Role
+  name: openclaw-editor
 subjects:
   - kind: ServiceAccount
     name: openclaw


### PR DESCRIPTION
Closes #3

## Summary
- Replaced the `ClusterRoleBinding` granting `cluster-admin` to the `openclaw` service account.
- Created a new `Role` named `openclaw-editor` that grants permissions to manage common resources only within the `openclaw` namespace.
- Created a `RoleBinding` to bind the new `Role` to the `openclaw` service account.
- This change follows the principle of least privilege to enhance cluster security.

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] `openclaw` pod starts and functions correctly
- [ ] Service health verified

---
Agent: devops-sre | OpenClaw Homelab