### PR TITLE
fix: enforce non-root execution for all workloads

### DIFF
--- a/k8s/apps/argocd/applications/authentik-app.yaml
+++ b/k8s/apps/argocd/applications/authentik-app.yaml
@@ -41,6 +41,10 @@ spec:
               type: none
 
         server:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
           replicas: 1
           service:
             type: NodePort
@@ -48,6 +52,10 @@ spec:
             nodePortHttps: 30501
 
         worker:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
           replicas: 1
 
         postgresql:

--- a/k8s/apps/argocd/applications/external-secrets-app.yaml
+++ b/k8s/apps/argocd/applications/external-secrets-app.yaml
@@ -26,6 +26,12 @@ spec:
             memory: 64Mi
           limits:
             memory: 256Mi
+        controller:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
   destination:
     server: https://kubernetes.default.svc
     namespace: external-secrets

--- a/k8s/apps/argocd/applications/monitoring-app.yaml
+++ b/k8s/apps/argocd/applications/monitoring-app.yaml
@@ -68,6 +68,11 @@ spec:
         # Prometheus
         prometheus:
           prometheusSpec:
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+              runAsNonRoot: true
+              fsGroup: 1000
             retention: 15d
             resources:
               requests:
@@ -87,6 +92,11 @@ spec:
         # Alertmanager
         alertmanager:
           alertmanagerSpec:
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+              runAsNonRoot: true
+              fsGroup: 1000
             resources:
               requests:
                 cpu: 50m

--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -95,6 +95,25 @@ Key settings:
 
 **Gitea** — configured via `gitea admin auth add-oauth` in the PostSync init job (`admin-init-job.yaml`). Client secret from `gitea-secret` ExternalSecret.
 
+## Non-Root Execution
+
+The Authentik server and worker containers run as non-root users (UID 1000) enforced by the pod's `securityContext`. This is set via the Helm values in the ArgoCD Application.
+
+```yaml
+server:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+worker:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+```
+
+This hardens the deployment by limiting the blast radius of a container escape.
+
 ## Networking
 
 | Layer | Value |

--- a/k8s/apps/external-secrets/README.md
+++ b/k8s/apps/external-secrets/README.md
@@ -76,6 +76,21 @@ If `external-secrets-config` syncs before the Helm chart installs the CRDs, it f
 
 Note: The `infisical-machine-identity` Kubernetes Secret referenced by the `ClusterSecretStore` is **not** in this directory — it is created by `terraform/bootstrap-secrets.tf` to avoid storing credentials in git.
 
+## Non-Root Execution
+
+The External Secrets Operator runs its controller as a non-root user (UID 1000) via the pod's `securityContext`. This is configured in the Helm values.
+
+```yaml
+controller:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    fsGroup: 1000
+```
+
+This reduces the attack surface and mitigates the impact of a potential container escape.
+
 ## ClusterSecretStore Configuration
 
 ```yaml

--- a/k8s/apps/gitea/README.md
+++ b/k8s/apps/gitea/README.md
@@ -223,6 +223,19 @@ The `gitea-data` PVC (10Gi, ReadWriteOnce) is mounted at `/data` and holds:
 | CPU | 100m | 500m |
 | Memory | 256Mi | 512Mi |
 
+## Non-Root Execution
+
+The Gitea container runs as a non-root user (`git` UID 1000) enforced by the pod's `securityContext`. This mitigates the impact of a container escape by limiting the attacker's privileges inside the host.
+
+```yaml
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+```
+
+The init container still runs as root to set up the configuration volume with correct ownership, then the main container drops to non-root.
+
 ## Integration with PostgreSQL
 
 Gitea depends on PostgreSQL for all persistent application data (users, repositories metadata, issues, pull requests, etc.). Git repository data (bare repos, LFS objects) is stored on the PVC.

--- a/k8s/apps/gitea/deployment.yaml
+++ b/k8s/apps/gitea/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         app.kubernetes.io/name: gitea
         app.kubernetes.io/instance: gitea
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       initContainers:
         - name: init-config
           image: busybox:1.36

--- a/k8s/apps/infisical/README.md
+++ b/k8s/apps/infisical/README.md
@@ -92,6 +92,21 @@ Contains a `values.yaml` blob injected via `helm.valuesObject` in the Terraform-
 
 Both are generated with `openssl rand -hex 12` and stored in `terraform/terraform.tfvars`.
 
+## Non-Root Execution
+
+The Infisical container runs as a non-root user (UID 1000) enforced by the pod's `securityContext`. This is set via the Helm `securityContext` values in the Terraform-managed Application:
+
+```yaml
+infisical:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    fsGroup: 1000
+```
+
+This reduces the risk of privilege escalation from a container escape.
+
 ## Project and Environment Structure
 
 ```mermaid

--- a/k8s/apps/monitoring/README.md
+++ b/k8s/apps/monitoring/README.md
@@ -103,6 +103,17 @@ Edit the `helm.valuesObject` in `k8s/apps/argocd/applications/monitoring-app.yam
 
 Update `targetRevision` in the Application CR to the desired chart version, then push to `main`.
 
+## Non-Root Execution
+
+All monitoring components are configured to run as non-root users:
+
+- **Grafana** runs as UID 472 (non-root) via its built-in `securityContext`.
+- **Prometheus** runs as UID 1000 with `runAsNonRoot: true`.
+- **Alertmanager** runs as UID 1000 with `runAsNonRoot: true`.
+- **Node Exporter** is not forced to non-root as it requires elevated privileges to collect system metrics.
+
+These settings are defined in the Helm values of the `monitoring-app.yaml` Application and help reduce the attack surface.
+
 ## Networking
 
 | Layer | Value |

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -284,6 +284,19 @@ kubectl get pods -n openclaw -w
 kubectl get externalsecret -n openclaw
 ```
 
+## Non-Root Execution
+
+The OpenClaw container runs as a non-root user (`node` UID 1000) enforced by the pod's `securityContext`. This is enabled by the Dockerfile `USER node` and the Kubernetes `securityContext` provides additional defense-in-depth.
+
+```yaml
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+```
+
+This ensures that even if a container escape occurs, the attacker's privileges within the host are limited to a non-root user.
+
 ## Networking
 
 ```mermaid

--- a/k8s/apps/openclaw/deployment.yaml
+++ b/k8s/apps/openclaw/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         app.kubernetes.io/instance: openclaw
     spec:
       serviceAccountName: openclaw
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       initContainers:
         - name: init-workspaces
           image: busybox:1.36

--- a/k8s/apps/postgresql/README.md
+++ b/k8s/apps/postgresql/README.md
@@ -160,6 +160,19 @@ kubectl rollout restart deployment gitea -n gitea-system
 | CPU | 100m | 500m |
 | Memory | 256Mi | 512Mi |
 
+## Non-Root Execution
+
+The PostgreSQL container runs as the non-root `postgres` user (UID 999), enforced by the pod's `securityContext`.
+
+```yaml
+securityContext:
+  runAsUser: 999
+  runAsGroup: 999
+  fsGroup: 999
+```
+
+This reduces the risk of privilege escalation from a container escape.
+
 ## Integration with Gitea
 
 Gitea connects to PostgreSQL using the Kubernetes Service DNS name:

--- a/k8s/apps/postgresql/deployment.yaml
+++ b/k8s/apps/postgresql/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         app.kubernetes.io/name: postgresql
         app.kubernetes.io/instance: gitea-db
     spec:
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
       containers:
         - name: postgresql
           image: postgres:15

--- a/terraform/argocd.tf
+++ b/terraform/argocd.tf
@@ -135,6 +135,12 @@ locals {
                 requests = { cpu = "100m", memory = "512Mi" }
                 limits   = { memory = "1500Mi" }
               }
+              securityContext = {
+                runAsUser    = 1000
+                runAsGroup   = 1000
+                runAsNonRoot = true
+                fsGroup      = 1000
+              }
             }
             ingress = { enabled = false }
             postgresql = {


### PR DESCRIPTION
Closes #4

## Summary
- Enforced non-root container execution across all workloads by adding `securityContext` with `runAsUser` and `runAsGroup` set to non-zero UIDs/GIDs.
- Updated manifests:
  - Gitea: added pod securityContext (runAsUser: 1000, fsGroup: 1000).
  - PostgreSQL: added pod securityContext (runAsUser: 999).
  - OpenClaw: added pod securityContext (runAsUser: 1000, fsGroup: 1000).
  - External Secrets: added `controller.securityContext` via Helm values (runAsUser: 1000, runAsNonRoot: true).
  - Authentik: added `server.securityContext` and `worker.securityContext` (runAsUser: 1000, runAsNonRoot: true).
  - Monitoring: added securityContext for Prometheus and Alertmanager (runAsUser: 1000, runAsNonRoot: true, fsGroup: 1000). Grafana already had non-root.
  - Infisical: added `infisical.securityContext` via Terraform Helm values (runAsUser: 1000, runAsNonRoot: true).
- Init containers remain root only where necessary to perform setup tasks (e.g., permissions), then main containers drop to non-root.

## Test plan
- [ ] ArgoCD syncs successfully for all Applications after securityContext additions.
- [ ] All pods start without `CannotRunPodError` or `SecurityContext`-related failures.
- [ ] `kubectl get pods -A` shows all containers in `Running` state.
- [ ] Verify non-root inside containers:
  - `kubectl exec -n gitea-system deploy/gitea -- id` should show UID 1000.
  - `kubectl exec -n gitea-system deploy/postgresql -- id` should show UID 999.
  - `kubectl exec -n openclaw deploy/openclaw -- id` should show UID 1000.
  - Similar checks for authentik, external-secrets, prometheus, alertmanager, infisical.
- [ ] Application functionality unchanged: Gitea UI accessible, Authentik SSO works, Grafana dashboards load, OpenClaw agents operate, ExternalSecrets syncs.
- [ ] No regression in PVC access (volumes writable by non-root user).

## Documentation
- Updated READMEs for each affected service to note the non-root enforcement and include example `securityContext` snippets.

---
Agent: security-analyst | OpenClaw Homelab
