### PR TITLE
feat: add stale PR triage and milestone reassessment procedures

### DIFF
--- a/agents/workspaces/homelab-admin/AGENTS.md
+++ b/agents/workspaces/homelab-admin/AGENTS.md
@@ -270,6 +270,19 @@ When all issues in a milestone are closed:
 
 5. **Report** the release URL to the user
 
+### Milestone reassessment (after incidents)
+
+When an incident causes reverts or scope changes, reassess the milestone before releasing:
+
+1. **Triage sibling PRs** — close unreviewed PRs from the same batch as the reverted PR (they share quality risks)
+2. **Move deferred work** — parent issues of closed PRs go to the next milestone
+3. **Assign orphaned merged PRs** — any merged PR without a milestone must be assigned
+4. **Update milestone description** — explain the scope change and rationale
+5. **Reassess version bump** — exclude `status:reverted` PRs from the version calculation
+6. **Release what's shipped** — don't hold a milestone open for deferred work; cut the release with what's already merged
+
+See the `incident-response` skill (Phase 6) for the full procedure.
+
 ## Incident Response
 
 You are the **incident commander** for the homelab cluster. When a deployment causes service degradation, you own the response.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -390,6 +390,44 @@ Owned by `homelab-admin` or the user — sub-agents never create tags or release
 4. Create a git tag and GitHub Release: `gh release create "v<version>" --target main --generate-notes --latest`
 5. Close the milestone and create the next one
 
+### Milestone reassessment
+
+When incidents, reverts, or scope changes alter a milestone's planned work, the release manager must reassess before cutting the release.
+
+**When to reassess:**
+
+- A PR in the milestone was merged then reverted
+- Sibling PRs from the same batch were closed without merge
+- Planned features were deferred to a future milestone
+- Orphaned merged PRs (no milestone) are discovered
+
+**Procedure:**
+
+1. **Triage sibling PRs** — unreviewed PRs created in the same batch as a reverted PR share the same quality risks. Close them and rewrite with proper pre-merge validation.
+
+2. **Move deferred work** — parent issues of closed PRs go to the next milestone with fresh per-service sub-issues.
+
+3. **Assign orphaned merged PRs** — any merged PR without a milestone must be assigned:
+
+```bash
+gh pr list --repo holdennguyen/homelab --state merged --json number,title,milestone \
+  --jq '.[] | select(.milestone == null) | "\(.number) | \(.title)"'
+```
+
+4. **Update milestone description** — explain the scope change:
+
+```bash
+gh api repos/holdennguyen/homelab/milestones/<number> --method PATCH \
+  -f description="<updated scope and rationale>"
+```
+
+5. **Reassess version bump** — if the only `type:feat` PRs were reverted, the effective bump may change (e.g., MINOR → PATCH).
+
+6. **Release what's shipped** — if the milestone has 0 open issues, cut the release with what's already merged. Don't hold a milestone open waiting for deferred work.
+
+!!! tip "Release what you have, not what you planned"
+    A milestone that lost its flagship feature to a revert is still releasable if it contains other merged work (infrastructure, docs, tooling). Rescope the description, adjust the version if needed, and ship it. Deferred features go to the next milestone.
+
 ## What NOT to Do
 
 - Never push directly to `main`

--- a/skills/gitops/SKILL.md
+++ b/skills/gitops/SKILL.md
@@ -439,6 +439,27 @@ gh api repos/holdennguyen/homelab/milestones/<milestone-number> \
   --method PATCH -f title="v<new-version>"
 ```
 
+### Milestone reassessment (after incidents or scope changes)
+
+When an incident causes reverts, stale PRs are closed, or planned work is deferred, the milestone scope changes. The release manager must reassess:
+
+1. **Triage sibling PRs** — unreviewed PRs from the same batch as a reverted PR should be closed (see `incident-response` skill, Phase 6)
+2. **Move deferred issues** — parent issues of closed PRs go to the next milestone
+3. **Assign orphaned merged PRs** — any merged PR without a milestone must be assigned to the current one
+4. **Update the milestone description** — explain the scope change and why
+5. **Reassess the version bump** — if the only `type:feat` PRs were reverted, the bump may drop from MINOR to PATCH
+6. **Release what's shipped** — if the milestone has 0 open issues, cut the release with what's already merged
+
+```bash
+# Find orphaned merged PRs
+gh pr list --repo holdennguyen/homelab --state merged --json number,title,milestone \
+  --jq '.[] | select(.milestone == null) | "\(.number) | \(.title)"'
+
+# Update milestone description
+gh api repos/holdennguyen/homelab/milestones/<number> --method PATCH \
+  -f description="<updated scope>"
+```
+
 ## Releases
 
 Releases are cut when a milestone is complete. The `homelab-admin` orchestrator (or the user) owns the release process. Sub-agents do NOT create releases or tags.

--- a/skills/incident-response/SKILL.md
+++ b/skills/incident-response/SKILL.md
@@ -346,13 +346,96 @@ When a merge and its revert both land in the same milestone:
 - If the reverted PR was the only `type:feat` in the milestone, the version bump may drop from MINOR to PATCH
 - The release manager should review milestone PRs for `status:reverted` before cutting the release
 
-### Summary checklist
+## Phase 6: Stale PR Review & Milestone Reassessment
+
+An incident often reveals systemic quality issues that affect sibling PRs created in the same batch. After the immediate cleanup, assess the broader milestone.
+
+### 1. Identify sibling PRs
+
+PRs created by the same agent, in the same time frame, or as part of the same task batch likely share the same quality risks:
+
+```bash
+# Find open PRs from the same agent
+gh pr list --repo holdennguyen/homelab --state open \
+  --label "agent:<agent-id>" --json number,title --jq '.[].title'
+
+# Find open PRs in the same milestone
+gh pr list --repo holdennguyen/homelab --state open \
+  --search "milestone:<version>" --json number,title --jq '.[].title'
+```
+
+### 2. Triage sibling PRs
+
+For each sibling PR, evaluate:
+
+| Question | If yes |
+|---|---|
+| Was it created in the same batch as the reverted PR? | High risk — likely same quality issues |
+| Has it been reviewed? | If not reviewed, close and rewrite |
+| Does it modify Helm `valuesObject`? | Verify keys with `helm show values` |
+| Does it make broad cross-service changes? | Break into per-service PRs |
+| Does it have a pre-merge validation checklist? | If missing, close and rewrite |
+
+**Decision matrix:**
+
+| PR state | Reviewed? | Action |
+|---|---|---|
+| Open, same batch | No | **Close** — rewrite with pre-merge validation |
+| Open, same batch | Yes, passed review | Re-review with incident learnings, merge if safe |
+| Open, different batch | No | Review normally, but apply heightened scrutiny |
+| Merged, not reverted | — | Spot-check for same class of issues |
+
+### 3. Reassess the milestone
+
+After closing stale PRs and moving issues, the milestone scope changes:
+
+```bash
+# Check milestone state
+gh api repos/holdennguyen/homelab/milestones --jq \
+  '.[] | select(.state=="open") | "\(.title): open=\(.open_issues), closed=\(.closed_issues)"'
+```
+
+**Milestone reassessment rules:**
+
+- **All planned features reverted or deferred** → rescope the milestone to what's already shipped (merged infrastructure, docs, tooling). Update the milestone description.
+- **Milestone has 0 open issues** → it's ready for release. Cut the release with what's there.
+- **Only `status:reverted` PRs remain as features** → the version bump drops (e.g., MINOR → PATCH if no net features).
+- **Unreviewed PRs from a failed batch** → close them, move their parent issues to the next milestone, create fresh per-service sub-issues.
+
+### 4. Update milestone description
+
+Reflect the new scope so anyone reading the milestone understands what changed and why:
+
+```bash
+gh api repos/holdennguyen/homelab/milestones/<number> --method PATCH \
+  -f description="<updated description explaining scope change and why>"
+```
+
+### 5. Assign orphaned merged PRs
+
+Merged PRs without a milestone create gaps in release tracking. Assign them to the current milestone:
+
+```bash
+# Find merged PRs with no milestone
+gh pr list --repo holdennguyen/homelab --state merged --json number,title,milestone \
+  --jq '.[] | select(.milestone == null) | "\(.number) | \(.title)"'
+
+# Assign each to the appropriate milestone
+gh pr edit <number> --milestone "v<version>" --repo holdennguyen/homelab
+```
+
+### Summary checklist (full post-incident)
 
 - [ ] Original issue reopened with revert explanation
 - [ ] Reverted PR labeled `status:reverted`
 - [ ] Original issue assigned to future milestone
 - [ ] Per-service sub-issues created for re-implementation
 - [ ] Post-incident report posted on the reverted PR
+- [ ] Sibling PRs triaged — unreviewed ones from same batch closed
+- [ ] Parent issues of closed sibling PRs moved to future milestone
+- [ ] Orphaned merged PRs assigned to milestones
+- [ ] Milestone description updated to reflect new scope
+- [ ] Release cut if milestone is ready (0 open issues)
 - [ ] Release manager notified of milestone impact
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Adds procedures for handling stale PRs and milestone reassessment after incidents, based on the v1.0.0 release experience where PRs #9 and #10 were closed and v1.0.0 was rescoped and released.

### Changes

**incident-response skill** — Phase 6: Stale PR Review & Milestone Reassessment
- Identify sibling PRs from failed batches
- Triage decision matrix (reviewed vs unreviewed, same batch vs different)
- Close unreviewed stale PRs, move parent issues to future milestones
- Assign orphaned merged PRs to milestones
- Updated full post-incident summary checklist

**gitops skill** — Milestone reassessment section
- When and how to reassess milestone scope after incidents
- Orphaned merged PR discovery commands

**git-workflow docs** — Milestone reassessment section
- Full procedure with commands
- Tip: "Release what you have, not what you planned"

**homelab-admin AGENTS.md** — Milestone reassessment under Release Management
- 6-step checklist for post-incident milestone handling

### Actions already taken for v1.0.0

| Action | Result |
|---|---|
| Closed PRs #9, #10 (unreviewed, same batch as reverted #11) | Done |
| Moved issues #2, #3 to v1.1.0 | Done |
| Assigned merged PRs #12, #19 to v1.0.0 | Done |
| Released v1.0.0 | https://github.com/holdennguyen/homelab/releases/tag/v1.0.0 |
| Closed v1.0.0 milestone | Done |

## Test plan
- [ ] Phase 6 follows existing skill structure
- [ ] Milestone reassessment sections are consistent across all 4 files
- [ ] Decision matrix is clear and actionable
