### PR TITLE
fix: require merge verification before branch deletion

### DIFF
--- a/.cursor/rules/homelab.mdc
+++ b/.cursor/rules/homelab.mdc
@@ -55,10 +55,28 @@ The `main` branch is **protected**. Never push directly to `main` — all change
    gh pr create --title "<type>: <description>" --body "<summary>"
    ```
 
+### Post-merge cleanup
+
+**Never delete a branch until the merge is confirmed.** Always verify before cleanup:
+
+```bash
+gh pr view <number> --json state,mergedAt --jq '"state: \(.state), merged: \(.mergedAt // "NOT MERGED")"'
+```
+
+Only proceed with deletion if the output shows `state: MERGED` and a merge timestamp. If the PR was closed without merging, do NOT delete the branch — the commits are only on that branch.
+
+```bash
+# Only after confirming MERGED:
+git checkout main && git pull origin main
+git branch -d <branch-name>
+git push origin --delete <branch-name>
+```
+
 ### Rules
 
 - **Never push to `main` directly** — branch protection will reject it
 - **Never force-push to `main`** — this is destructive and irreversible
+- **Never delete a branch without verifying the PR was merged** — use `gh pr view` to confirm
 - One PR per logical change — don't bundle unrelated changes
 - Include documentation updates in the same PR as the implementation
 - Never commit secrets, API keys, or credentials

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -72,13 +72,20 @@ git push -u origin HEAD
 gh pr create --title "<type>: <description>" --body "<summary>"
 ```
 
-6. **After merge**, clean up:
+6. **After merge**, verify and clean up:
 
 ```bash
+# ALWAYS verify the PR was actually merged before deleting the branch
+gh pr view <number> --json state,mergedAt --jq '"state: \(.state), merged: \(.mergedAt // "NOT MERGED")"'
+
+# Only proceed if state is MERGED:
 git checkout main && git pull origin main
 git branch -d <branch-name>
 git push origin --delete <branch-name>
 ```
+
+!!! danger "Never delete a branch without confirming merge"
+    If a PR is closed without merging, the commits exist **only** on that branch. Deleting it loses the work and requires recovery from `git reflog`. Always check `gh pr view` first.
 
 ### Branch naming
 
@@ -432,6 +439,7 @@ gh api repos/holdennguyen/homelab/milestones/<number> --method PATCH \
 
 - Never push directly to `main`
 - Never force-push to `main`
+- Never delete a branch without verifying the PR was merged (`gh pr view <number> --json state,mergedAt`)
 - Never commit secrets, API keys, or credentials
 - Never bundle unrelated changes in one PR
 - Never assume a Helm value key exists — always verify with `helm show values`
@@ -453,9 +461,11 @@ git add . && git commit -m "feat: my feature"
 git fetch origin main && git merge origin/main --no-edit
 git push -u origin HEAD
 gh pr create --title "feat: my feature" --body "Summary of changes"
-# After merge:
+# After merge — verify BEFORE deleting:
+gh pr view <number> --json state --jq '.state'  # must say MERGED
 git checkout main && git pull origin main
 git branch -d feat/my-feature
+git push origin --delete feat/my-feature
 ```
 
 ### OpenClaw agent

--- a/skills/gitops/SKILL.md
+++ b/skills/gitops/SKILL.md
@@ -218,6 +218,14 @@ Example: `devops-sre/feat/42-redis-caching`
 
 ### After merge
 
+**Before cleaning up, verify the PR was actually merged:**
+
+```bash
+gh pr view <number> --json state,mergedAt --jq '"state: \(.state), merged: \(.mergedAt // "NOT MERGED")"'
+```
+
+Only delete the branch if the state is `MERGED`. If the PR was closed without merging, the commits exist only on that branch — deleting it loses the work.
+
 - **Layer 1 (k8s manifests):** ArgoCD auto-syncs within ~3 minutes. Verify: `kubectl get applications -n argocd`
 - **Layer 0 (Terraform):** Requires manual `terraform apply` on the host after merge.
 - **Docker image changes:** Requires `./scripts/build-openclaw.sh` + `kubectl rollout restart` on the host.
@@ -316,6 +324,7 @@ git push origin main
 - Never use a branch name without the `<agent-id>/` prefix
 - Never assume a Helm value key exists — always verify with `helm show values` or `helm template`
 - Never apply `securityContext` changes without verifying image compatibility
+- Never delete a branch without verifying the PR was merged — use `gh pr view <number> --json state,mergedAt`
 
 ## App of Apps pattern
 


### PR DESCRIPTION
## Summary

Adds a mandatory safeguard: **always verify a PR was merged before deleting its branch**.

This prevents the scenario (hit twice with PRs #18 and #20) where a PR is closed without merging and the branch is deleted, requiring recovery from `git reflog` and a new PR.

### The rule

Before any branch deletion, run:

```bash
gh pr view <number> --json state,mergedAt --jq '"state: \(.state), merged: \(.mergedAt // "NOT MERGED")"'
```

Only proceed if `state: MERGED`. If the PR was closed without merging, the commits exist only on that branch.

### Files changed

- `.cursor/rules/homelab.mdc` — post-merge cleanup section with verification command + new rule
- `skills/gitops/SKILL.md` — after-merge verification + what-not-to-do list
- `docs/git-workflow.md` — step 6 updated, danger admonition, what-not-to-do, quick reference

## Test plan
- [x] Verification command is consistent across all three files
- [x] Cursor rule clearly blocks deletion without confirmation
- [x] Quick reference in docs includes the check
