### PR TITLE
feat: add documentation freshness tracking system

### DIFF
--- a/.cursor/rules/homelab.mdc
+++ b/.cursor/rules/homelab.mdc
@@ -95,6 +95,17 @@ Before merging PRs that modify cluster resources:
 
 After every implementation, update the related documentation before considering the task complete. This is not optional.
 
+### Doc freshness tracking
+
+The repo uses `.doc-manifest.yml` to map every documentation file to its implementation sources. Before creating a PR, run:
+
+```bash
+python scripts/doc-freshness.py --check-pr    # which docs this branch should update
+python scripts/doc-freshness.py --stale       # full staleness report
+```
+
+The `doc-freshness` GitHub Actions workflow runs on every PR and will comment if mapped docs are missing updates. The manifest is the **source of truth** for doc-to-source relationships — when adding a new service or doc, add an entry to `.doc-manifest.yml`.
+
 ### Single source of truth: `k8s/apps/<service>/README.md`
 
 Every service directory under `k8s/apps/` **must** have a `README.md`. This README is the **single source of truth** for that service's documentation. The corresponding `docs/<service>.md` is always a thin MkDocs wrapper that includes the README:
@@ -141,9 +152,10 @@ Every `k8s/apps/<service>/README.md` should include these sections (adapt as nee
 1. Create `k8s/apps/<service>/README.md` following the README structure above
 2. Create `docs/<service>.md` as a thin `include-markdown` wrapper (see template above)
 3. Add `<service>.md` to the `nav` in `mkdocs.yml`
-4. Update the service map and repository layout in `docs/architecture.md`
-5. If the service has secrets, update `docs/secret-management.md` and `k8s/apps/infisical/README.md` inventory
-6. If the service has a Tailscale endpoint, update `docs/networking.md` and `docs/bootstrap.md` (Tailscale Serve commands)
+4. Add doc → source mapping to `.doc-manifest.yml`
+5. Update the service map and repository layout in `docs/architecture.md`
+6. If the service has secrets, update `docs/secret-management.md` and `k8s/apps/infisical/README.md` inventory
+7. If the service has a Tailscale endpoint, update `docs/networking.md` and `docs/bootstrap.md` (Tailscale Serve commands)
 
 ### Rules
 

--- a/.doc-manifest.yml
+++ b/.doc-manifest.yml
@@ -1,0 +1,95 @@
+# Documentation Freshness Manifest
+#
+# Maps each documentation file to the implementation directories it covers.
+# Used by scripts/doc-freshness.py to detect stale documentation.
+#
+# How it works:
+#   For each entry, the script compares the last git commit that touched the doc
+#   vs the last commit that touched any file in its sources (excluding the doc itself).
+#   If the sources are newer, the doc is flagged as stale.
+#
+# Rules:
+#   - Every doc with real content should be listed here
+#   - Thin MkDocs wrappers (docs/<service>.md that just include-markdown a README) are excluded
+#   - sources are path prefixes matched against git file paths
+#   - When adding a new service, add its README entry here
+
+documents:
+  # ── Root ──
+  - doc: README.md
+    sources:
+      - k8s/apps/
+      - terraform/
+      - agents/
+      - skills/
+      - scripts/
+      - mkdocs.yml
+      - .github/workflows/
+
+  # ── Service READMEs (single source of truth per service) ──
+  - doc: k8s/apps/argocd/README.md
+    sources:
+      - k8s/apps/argocd/
+
+  - doc: k8s/apps/authentik/README.md
+    sources:
+      - k8s/apps/authentik/
+
+  - doc: k8s/apps/external-secrets/README.md
+    sources:
+      - k8s/apps/external-secrets/
+
+  - doc: k8s/apps/gitea/README.md
+    sources:
+      - k8s/apps/gitea/
+
+  - doc: k8s/apps/infisical/README.md
+    sources:
+      - k8s/apps/infisical/
+
+  - doc: k8s/apps/monitoring/README.md
+    sources:
+      - k8s/apps/monitoring/
+
+  - doc: k8s/apps/openclaw/README.md
+    sources:
+      - k8s/apps/openclaw/
+
+  - doc: k8s/apps/postgresql/README.md
+    sources:
+      - k8s/apps/postgresql/
+
+  - doc: terraform/README.md
+    sources:
+      - terraform/
+
+  # ── Cross-cutting documentation (real content, not thin wrappers) ──
+  - doc: docs/architecture.md
+    sources:
+      - k8s/apps/argocd/
+      - terraform/
+
+  - doc: docs/bootstrap.md
+    sources:
+      - terraform/
+
+  - doc: docs/secret-management.md
+    sources:
+      - k8s/apps/external-secrets/
+      - k8s/apps/infisical/
+
+  - doc: docs/networking.md
+    sources:
+      - k8s/apps/
+
+  - doc: docs/ai-agents.md
+    sources:
+      - agents/
+      - skills/
+      - .cursor/rules/
+
+  - doc: docs/git-workflow.md
+    sources:
+      - .cursor/rules/homelab.mdc
+      - .github/workflows/
+      - skills/incident-response/

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -1,0 +1,89 @@
+name: Doc Freshness
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check PR for missing doc updates
+        id: pr_check
+        run: |
+          echo "## 📄 Documentation Freshness" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if python scripts/doc-freshness.py --check-pr --markdown >> "$GITHUB_STEP_SUMMARY" 2>&1; then
+            echo "status=pass" >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No documentation gaps detected." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "status=warn" >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> **Action needed:** update the listed docs or verify they don't need changes." >> "$GITHUB_STEP_SUMMARY"
+            echo "> Run \`python scripts/doc-freshness.py --check-pr\` locally to reproduce." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Full freshness report
+        if: always()
+        run: |
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "<details><summary>Full freshness report</summary>" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          python scripts/doc-freshness.py --markdown >> "$GITHUB_STEP_SUMMARY" 2>&1 || true
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR if docs are stale
+        if: steps.pr_check.outputs.status == 'warn'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- doc-freshness-bot -->';
+            const body = [
+              marker,
+              '### 📄 Documentation Freshness Warning',
+              '',
+              'This PR changes implementation files that have mapped documentation, but the docs were not updated.',
+              '',
+              'Please review the **Doc Freshness** check in the Actions tab for details, or run locally:',
+              '```bash',
+              'python scripts/doc-freshness.py --check-pr',
+              '```',
+              '',
+              '> This is a warning — it does not block merge. If the docs genuinely don\'t need updating, this is safe to ignore.',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ flowchart TD
 ```
 homelab/
 ├── README.md
+├── .doc-manifest.yml              # Doc freshness manifest (doc → source mappings)
 ├── mkdocs.yml                     # MkDocs Material site config
 ├── Dockerfile.openclaw            # Homelab overlay for OpenClaw image
-├── .gitignore                     # Excludes terraform.tfvars and .terraform/
+├── .gitignore                     # Excludes terraform state/tfvars, site/, .DS_Store
 ├── .github/workflows/docs.yml    # GitHub Pages deploy on push to main
+├── .github/workflows/doc-freshness.yml  # PR check for stale documentation
 ├── terraform/                     # Bootstrap layer (run once, not GitOps)
 │   ├── providers.tf               # kubernetes + helm provider config
 │   ├── argocd.tf                  # ArgoCD Helm release + root Application CR
@@ -104,8 +106,11 @@ homelab/
 │       ├── openclaw/              # OpenClaw AI gateway kustomize manifests
 │       └── postgresql/            # PostgreSQL kustomize manifests + ExternalSecret
 ├── docs/                          # MkDocs documentation site
-├── agents/workspaces/             # OpenClaw agent AGENTS.md personalities
-├── skills/                        # OpenClaw homelab-specific skills
+├── agents/                        # OpenClaw agent definitions
+│   ├── root_rules.md              # Shared rules for all agents
+│   ├── <role>_agent/              # Agent personality definitions (6 roles)
+│   └── workspaces/                # Per-agent AGENTS.md workspace configs
+├── skills/                        # OpenClaw homelab-specific skills (9 domains)
 ├── openclaw/                      # OpenClaw source (git submodule)
 └── scripts/                       # Helper scripts (image builds, etc.)
 ```
@@ -252,12 +257,32 @@ kubectl get pods -A | grep -v Running | grep -v Completed
 | [docs/monitoring.md](docs/monitoring.md) | Grafana + Prometheus stack, dashboards, SSO integration |
 | [docs/openclaw.md](docs/openclaw.md) | OpenClaw AI gateway deployment, image builds, multi-agent architecture |
 | [docs/ai-agents.md](docs/ai-agents.md) | Cursor rules + OpenClaw agents/skills, when to use which |
+| [docs/git-workflow.md](docs/git-workflow.md) | Branch conventions, PR requirements, post-merge cleanup for Cursor and OpenClaw |
 | [terraform/README.md](terraform/README.md) | All Terraform variables, what resources are managed, day-2 operations |
 | [k8s/apps/argocd/README.md](k8s/apps/argocd/README.md) | App of Apps pattern, sync waves, adding new applications |
+| [k8s/apps/authentik/README.md](k8s/apps/authentik/README.md) | Authentik SSO deployment, ExternalSecret, OIDC provider configuration |
 | [k8s/apps/infisical/README.md](k8s/apps/infisical/README.md) | Infisical deployment, first-time setup, machine identity, bootstrap secrets |
 | [k8s/apps/external-secrets/README.md](k8s/apps/external-secrets/README.md) | ClusterSecretStore, ExternalSecret pattern, adding secrets for new services |
 | [k8s/apps/gitea/README.md](k8s/apps/gitea/README.md) | Config seeding via init container, env var overrides, ExternalSecret integration |
+| [k8s/apps/monitoring/README.md](k8s/apps/monitoring/README.md) | Grafana + Prometheus monitoring stack, ExternalSecret, SSO integration |
+| [k8s/apps/openclaw/README.md](k8s/apps/openclaw/README.md) | OpenClaw AI gateway deployment, configuration, image builds |
 | [k8s/apps/postgresql/README.md](k8s/apps/postgresql/README.md) | Database configuration, pg_hba.conf, PGDATA layout, password management |
+
+## Documentation Freshness Tracking
+
+Every documentation file is mapped to its implementation sources in [`.doc-manifest.yml`](.doc-manifest.yml). A Python script compares git history to detect when docs fall behind their sources.
+
+```bash
+python scripts/doc-freshness.py              # Full freshness report
+python scripts/doc-freshness.py --stale      # Only stale docs
+python scripts/doc-freshness.py --check-pr   # Check current branch for missing doc updates
+python scripts/doc-freshness.py --json       # JSON output (for automation)
+python scripts/doc-freshness.py --markdown   # Markdown table (for PR comments)
+```
+
+The [`doc-freshness`](.github/workflows/doc-freshness.yml) GitHub Actions workflow runs on every PR to `main`. If implementation sources changed but mapped docs were not updated, it posts a warning comment on the PR with a link to the details. The check is advisory — it does not block merge.
+
+When adding a new service or documentation file, add an entry to `.doc-manifest.yml` so the freshness system tracks it.
 
 ## Future Plans
 

--- a/scripts/doc-freshness.py
+++ b/scripts/doc-freshness.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Documentation freshness checker.
+
+Reads .doc-manifest.yml and uses git history to detect stale documentation.
+Reports which docs need updating and how far behind they are.
+
+Usage:
+    scripts/doc-freshness.py                  # Full freshness report
+    scripts/doc-freshness.py --stale          # Only show stale docs
+    scripts/doc-freshness.py --check-pr       # Check files changed on current branch vs main
+    scripts/doc-freshness.py --json           # JSON output (for CI pipelines)
+    scripts/doc-freshness.py --markdown       # Markdown table (for PR comments)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class DocEntry:
+    doc: str
+    sources: list[str]
+
+
+@dataclass
+class FreshnessResult:
+    doc: str
+    exists: bool
+    stale: bool
+    doc_commit: str | None = None
+    doc_timestamp: int | None = None
+    source_commit: str | None = None
+    source_timestamp: int | None = None
+    commits_behind: int = 0
+
+
+# ── Manifest parser (no PyYAML dependency) ──────────────────────────────────
+
+def parse_manifest(path: str) -> list[DocEntry]:
+    """Parse the simple YAML manifest structure without external dependencies."""
+    entries: list[DocEntry] = []
+    current_doc: str | None = None
+    current_sources: list[str] = []
+    in_sources = False
+
+    with open(path) as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+
+            if stripped.startswith("- doc:"):
+                if current_doc is not None:
+                    entries.append(DocEntry(doc=current_doc, sources=current_sources))
+                current_doc = stripped.split(":", 1)[1].strip()
+                current_sources = []
+                in_sources = False
+            elif stripped == "sources:":
+                in_sources = True
+            elif in_sources and stripped.startswith("- "):
+                current_sources.append(stripped[2:].strip())
+            elif stripped == "documents:":
+                continue
+            else:
+                in_sources = False
+
+    if current_doc is not None:
+        entries.append(DocEntry(doc=current_doc, sources=current_sources))
+
+    return entries
+
+
+# ── Git helpers ──────────────────────────────────────────────────────────────
+
+REPO_ROOT: str | None = None
+
+
+def repo_root() -> str:
+    global REPO_ROOT
+    if REPO_ROOT is None:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        )
+        REPO_ROOT = result.stdout.strip()
+    return REPO_ROOT
+
+
+def git_last_commit(paths: list[str], exclude: str | None = None) -> tuple[str | None, int | None]:
+    """Return (short_hash, unix_timestamp) of the most recent commit touching paths."""
+    cmd = ["git", "log", "-1", "--format=%H %ct", "--"]
+    cmd.extend(paths)
+    if exclude:
+        cmd.append(f":!{exclude}")
+
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=repo_root())
+    output = result.stdout.strip()
+    if not output:
+        return None, None
+    parts = output.split()
+    return parts[0][:8], int(parts[1])
+
+
+def git_commits_between(
+    older_hash: str, newer_hash: str, paths: list[str], exclude: str | None = None,
+) -> int:
+    """Count commits between two refs, scoped to paths."""
+    cmd = ["git", "rev-list", "--count", f"{older_hash}..{newer_hash}", "--"]
+    cmd.extend(paths)
+    if exclude:
+        cmd.append(f":!{exclude}")
+
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=repo_root())
+    return int(result.stdout.strip()) if result.stdout.strip() else 0
+
+
+def git_changed_files_on_branch(base: str = "origin/main") -> set[str]:
+    """Return the set of file paths changed on the current branch vs base."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        capture_output=True, text=True, cwd=repo_root(),
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return set()
+    return set(result.stdout.strip().splitlines())
+
+
+# ── Core logic ───────────────────────────────────────────────────────────────
+
+def check_freshness(entries: list[DocEntry]) -> list[FreshnessResult]:
+    results: list[FreshnessResult] = []
+
+    for entry in entries:
+        doc_path = Path(repo_root()) / entry.doc
+
+        if not doc_path.exists():
+            results.append(FreshnessResult(doc=entry.doc, exists=False, stale=True))
+            continue
+
+        doc_hash, doc_ts = git_last_commit([entry.doc])
+        src_hash, src_ts = git_last_commit(entry.sources, exclude=entry.doc)
+
+        if not src_hash:
+            stale, behind = False, 0
+        elif not doc_hash:
+            stale, behind = True, -1
+        elif src_ts and doc_ts and src_ts > doc_ts:
+            stale = True
+            behind = git_commits_between(doc_hash, src_hash, entry.sources, exclude=entry.doc)
+        else:
+            stale, behind = False, 0
+
+        results.append(FreshnessResult(
+            doc=entry.doc,
+            exists=True,
+            stale=stale,
+            doc_commit=doc_hash,
+            doc_timestamp=doc_ts,
+            source_commit=src_hash,
+            source_timestamp=src_ts,
+            commits_behind=behind,
+        ))
+
+    return results
+
+
+def check_pr(entries: list[DocEntry], base: str = "origin/main") -> list[dict]:
+    """Check which docs should have been updated in the current branch."""
+    changed = git_changed_files_on_branch(base)
+    if not changed:
+        return []
+
+    warnings: list[dict] = []
+    for entry in entries:
+        source_touched = False
+        for f in changed:
+            if f == entry.doc:
+                continue
+            for src in entry.sources:
+                if f.startswith(src) or f == src:
+                    source_touched = True
+                    break
+            if source_touched:
+                break
+
+        if source_touched and entry.doc not in changed:
+            warnings.append({
+                "doc": entry.doc,
+                "sources": entry.sources,
+                "message": f"Implementation sources changed but {entry.doc} was not updated",
+            })
+
+    return warnings
+
+
+# ── Formatting ───────────────────────────────────────────────────────────────
+
+def time_ago(ts: int | None) -> str:
+    if ts is None:
+        return "never"
+    delta = datetime.now(tz=timezone.utc) - datetime.fromtimestamp(ts, tz=timezone.utc)
+    if delta.days > 30:
+        return f"{delta.days // 30}mo ago"
+    if delta.days > 0:
+        return f"{delta.days}d ago"
+    if delta.seconds > 3600:
+        return f"{delta.seconds // 3600}h ago"
+    return f"{delta.seconds // 60}m ago"
+
+
+def print_table(results: list[FreshnessResult], stale_only: bool = False) -> None:
+    items = [r for r in results if r.stale] if stale_only else results
+    if not items:
+        print("\n  All documentation is up-to-date.\n")
+        return
+
+    col = max(len(r.doc) for r in items)
+
+    print()
+    print(f"  {'Document':<{col}}  {'Status':<8}  {'Doc':<10}  {'Source':<10}  {'Behind'}")
+    print(f"  {'─' * col}  {'─' * 8}  {'─' * 10}  {'─' * 10}  {'─' * 10}")
+
+    for r in items:
+        icon = "✗" if r.stale else "✓"
+        status = "MISSING" if not r.exists else ("STALE" if r.stale else "ok")
+        doc_ref = r.doc_commit or "—"
+        src_ref = r.source_commit or "—"
+        behind = f"{r.commits_behind} commits" if r.commits_behind > 0 else "—"
+        print(f"  {icon} {r.doc:<{col}}  {status:<8}  {doc_ref:<10}  {src_ref:<10}  {behind}")
+
+    stale_n = sum(1 for r in results if r.stale)
+    fresh_n = len(results) - stale_n
+    print(f"\n  Summary: {fresh_n}/{len(results)} up-to-date, {stale_n} stale\n")
+
+
+def print_markdown(results: list[FreshnessResult]) -> None:
+    """Markdown table suitable for PR comments."""
+    stale = [r for r in results if r.stale]
+    if not stale:
+        print("All documentation is up-to-date.")
+        return
+
+    print("| Status | Document | Doc commit | Source commit | Behind |")
+    print("|--------|----------|------------|---------------|--------|")
+    for r in stale:
+        status = "MISSING" if not r.exists else "STALE"
+        doc_ref = f"`{r.doc_commit}`" if r.doc_commit else "—"
+        src_ref = f"`{r.source_commit}`" if r.source_commit else "—"
+        behind = f"{r.commits_behind}" if r.commits_behind > 0 else "—"
+        print(f"| {status} | `{r.doc}` | {doc_ref} | {src_ref} | {behind} |")
+
+
+def print_pr_warnings(warnings: list[dict]) -> None:
+    if not warnings:
+        print("\n  All affected docs are updated in this branch.\n")
+        return
+    print(f"\n  ⚠  {len(warnings)} doc(s) may need updating:\n")
+    for w in warnings:
+        print(f"  • {w['doc']}")
+        print(f"    {w['message']}")
+    print()
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check documentation freshness against implementation sources",
+    )
+    parser.add_argument("--stale", action="store_true", help="Only show stale docs")
+    parser.add_argument("--check-pr", action="store_true", help="Check current branch for missing doc updates")
+    parser.add_argument("--base", default="origin/main", help="Base branch for --check-pr (default: origin/main)")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    parser.add_argument("--markdown", action="store_true", help="Markdown table output")
+    parser.add_argument("--manifest", default=".doc-manifest.yml", help="Path to manifest (default: .doc-manifest.yml)")
+    args = parser.parse_args()
+
+    manifest_path = Path(repo_root()) / args.manifest
+    if not manifest_path.exists():
+        print(f"Error: manifest not found at {manifest_path}", file=sys.stderr)
+        sys.exit(2)
+
+    entries = parse_manifest(str(manifest_path))
+
+    # ── PR mode ──────────────────────────────────────────────────────────
+    if args.check_pr:
+        warnings = check_pr(entries, base=args.base)
+        if args.json:
+            print(json.dumps(warnings, indent=2))
+        elif args.markdown:
+            if warnings:
+                print("| Document | Issue |")
+                print("|----------|-------|")
+                for w in warnings:
+                    print(f"| `{w['doc']}` | {w['message']} |")
+            else:
+                print("All affected docs are updated in this branch.")
+        else:
+            print_pr_warnings(warnings)
+        sys.exit(1 if warnings else 0)
+
+    # ── Full freshness report ────────────────────────────────────────────
+    results = check_freshness(entries)
+    has_stale = any(r.stale for r in results)
+
+    if args.json:
+        data = [
+            {k: v for k, v in asdict(r).items() if k != "exists" or not r.exists}
+            for r in results
+        ]
+        print(json.dumps(data, indent=2))
+    elif args.markdown:
+        print_markdown(results)
+    else:
+        print_table(results, stale_only=args.stale)
+
+    sys.exit(1 if has_stale else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a **documentation freshness tracking system** that maps every doc to its implementation sources and detects when docs fall behind
- `.doc-manifest.yml` is the source of truth: 16 doc-to-source mappings covering all service READMEs and cross-cutting docs
- `scripts/doc-freshness.py` is a zero-dependency Python CLI with 5 output modes (`--stale`, `--check-pr`, `--json`, `--markdown`, default table)
- `.github/workflows/doc-freshness.yml` runs on every PR to `main`, posts a warning comment when mapped docs are missing updates (advisory, non-blocking)
- Updated `.cursor/rules/homelab.mdc` to reference the freshness system and added step 4 (`.doc-manifest.yml` entry) to the new-service checklist
- Updated `README.md`: added freshness tracking section, fixed repo structure (agents/, .gitignore description), added 4 missing doc entries (git-workflow, authentik/monitoring/openclaw READMEs)

## Test plan

- [x] `python scripts/doc-freshness.py` — full report renders correctly (8/16 up-to-date, 8 stale)
- [x] `python scripts/doc-freshness.py --stale` — filters to stale only
- [x] `python scripts/doc-freshness.py --json` — valid JSON output
- [x] `python scripts/doc-freshness.py --markdown` — renders as markdown table
- [x] Script syntax validated with `ast.parse`
- [x] `doc-freshness` GitHub Actions workflow runs on this PR


Made with [Cursor](https://cursor.com)