### PR TITLE
docs: document doc freshness strategy in git-workflow and ai-agents

### DIFF
--- a/.doc-manifest.yml
+++ b/.doc-manifest.yml
@@ -87,9 +87,13 @@ documents:
       - agents/
       - skills/
       - .cursor/rules/
+      - scripts/doc-freshness.py
+      - .doc-manifest.yml
 
   - doc: docs/git-workflow.md
     sources:
       - .cursor/rules/homelab.mdc
       - .github/workflows/
       - skills/incident-response/
+      - scripts/doc-freshness.py
+      - .doc-manifest.yml

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -374,6 +374,31 @@ metadata:
 
 Skills auto-load via `skills.load.extraDirs: ["/skills"]` in the OpenClaw config.
 
+## Documentation Maintenance
+
+Both Cursor and OpenClaw agents are expected to keep documentation up-to-date as part of every implementation. The repo includes a **documentation freshness tracking system** to make this verifiable.
+
+### For agents
+
+Before creating a PR, run the freshness checker to see if your changes require doc updates:
+
+```bash
+python scripts/doc-freshness.py --check-pr     # Which docs this branch should update
+python scripts/doc-freshness.py --stale        # Full staleness report across all docs
+```
+
+The tool reads `.doc-manifest.yml` (which maps every doc to its implementation sources) and compares git commit timestamps. If sources are newer than their mapped doc, the doc is flagged as stale with the number of commits behind.
+
+The `doc-freshness` CI workflow runs automatically on every PR to `main` and will post a warning comment if mapped docs are missing updates. The check is advisory — it does not block merge.
+
+### What to update
+
+The `.cursor/rules/homelab.mdc` file contains the full "What to update" table mapping change areas to docs. The key rule: **every service directory under `k8s/apps/` must have a `README.md`** that serves as the single source of truth. The corresponding `docs/<service>.md` is a thin MkDocs wrapper that includes the README.
+
+### When adding a new service
+
+Add an entry to `.doc-manifest.yml` mapping the new service's README to its source directory. This ensures the freshness system tracks it going forward. See the full checklist in `.cursor/rules/homelab.mdc` under "Adding a new service."
+
 ## Single Source of Truth
 
 | Content | Source | Consumed By |
@@ -382,5 +407,6 @@ Skills auto-load via `skills.load.extraDirs: ["/skills"]` in the OpenClaw config
 | Agent personalities | `agents/workspaces/*/AGENTS.md` | OpenClaw (copied into pod workspace by init container) |
 | Operational skills | `skills/*/SKILL.md` | OpenClaw (mounted at `/skills`), Cursor (read on demand) |
 | Agent roster & config | `k8s/apps/openclaw/configmap.yaml` | OpenClaw (mounted at `/config`) |
+| Doc-to-source mappings | `.doc-manifest.yml` | `scripts/doc-freshness.py`, `doc-freshness` CI workflow |
 
 There is no duplication. Each piece of content has exactly one source file in git.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -288,6 +288,77 @@ helm template <release> <repo>/<chart> --version <version> \
 - [ ] Shared resources (ClusterRoles, CRDs) are not removed or renamed
 - [ ] ExternalSecrets still reference valid keys
 
+## Documentation Freshness Checks
+
+Every documentation file is mapped to its implementation sources in [`.doc-manifest.yml`](https://github.com/holdennguyen/homelab/blob/main/.doc-manifest.yml). A CI workflow and CLI tool use git history to detect when docs fall behind.
+
+### How it works
+
+```mermaid
+flowchart LR
+    Manifest[".doc-manifest.yml\n(doc → source mappings)"]
+    Script["scripts/doc-freshness.py"]
+    Git["git log\n(commit timestamps)"]
+
+    Manifest --> Script
+    Git --> Script
+    Script -->|"source newer than doc"| Stale["STALE\n(X commits behind)"]
+    Script -->|"doc newer or equal"| Fresh["OK"]
+```
+
+For each entry in the manifest, the script compares the **last commit that touched the doc** vs the **last commit that touched any file in its source directories** (excluding the doc itself). If the source is newer, the doc is stale and the report shows how many commits behind it is.
+
+### CI workflow (`doc-freshness`)
+
+The [`doc-freshness`](https://github.com/holdennguyen/homelab/blob/main/.github/workflows/doc-freshness.yml) GitHub Actions workflow runs on every PR to `main`:
+
+1. Examines which files the PR changes
+2. Checks those files against the manifest to find mapped docs
+3. If a mapped doc was **not** updated in the PR, it posts a warning comment
+
+The check is **advisory only** — it does not block merge. If the docs genuinely don't need updating (e.g., a comment change in a source file), the warning is safe to ignore.
+
+### Local usage
+
+```bash
+python scripts/doc-freshness.py                # Full freshness table
+python scripts/doc-freshness.py --stale        # Only stale docs
+python scripts/doc-freshness.py --check-pr     # Files changed on current branch vs origin/main
+python scripts/doc-freshness.py --json         # Machine-readable JSON
+python scripts/doc-freshness.py --markdown     # Markdown table for PR comments
+```
+
+!!! note "`--check-pr` requires a feature branch"
+    The `--check-pr` flag compares `HEAD` against `origin/main`. If you run it on `main` after a merge, there's no diff and it reports "all up-to-date." Always run it from a feature branch before pushing.
+
+### Interpreting the report
+
+```
+  Document                             Status    Doc         Source      Behind
+  ───────────────────────────────────  ────────  ──────────  ──────────  ──────────
+  ✓ k8s/apps/gitea/README.md            ok        3cce3e9c    05e88155    —
+  ✗ docs/networking.md                   STALE     331be14f    f591ad60    25 commits
+```
+
+| Column | Meaning |
+|---|---|
+| Status | `ok` = doc is current, `STALE` = sources are newer, `MISSING` = doc file doesn't exist |
+| Doc | Short hash of the last commit that touched the doc |
+| Source | Short hash of the last commit that touched any source (excluding the doc itself) |
+| Behind | Number of source commits since the doc was last updated |
+
+### Adding a new entry
+
+When creating a new service or documentation file, add an entry to `.doc-manifest.yml`:
+
+```yaml
+- doc: k8s/apps/my-service/README.md
+  sources:
+    - k8s/apps/my-service/
+```
+
+For cross-cutting docs that cover multiple areas, list all relevant source directories.
+
 ## Post-Merge Verification
 
 After every merge to `main`, verify the deployment succeeded:


### PR DESCRIPTION
## Summary

- Adds a full **Documentation Freshness Checks** section to `docs/git-workflow.md` covering how the system works (mermaid diagram), the CI workflow, local CLI usage with all flags, how to interpret reports, and how to add new entries
- Adds a **Documentation Maintenance** section to `docs/ai-agents.md` explaining how agents should use the freshness checker before PRs, and adds `.doc-manifest.yml` to the Single Source of Truth table
- Updates `.doc-manifest.yml` to include `scripts/doc-freshness.py` and `.doc-manifest.yml` as sources for `docs/git-workflow.md` and `docs/ai-agents.md`, so changes to the freshness system itself are tracked

This resolves the `doc-freshness` CI warning from PR #23, which correctly flagged that `.cursor/rules/homelab.mdc` and `.github/workflows/` changed without updating the mapped docs.

## Test plan

- [ ] `doc-freshness` CI workflow passes (no warnings for this PR since the flagged docs are updated)
- [ ] `docs/git-workflow.md` renders correctly in MkDocs with mermaid diagram and admonition
- [ ] `docs/ai-agents.md` renders correctly with new section and updated table


Made with [Cursor](https://cursor.com)