### PR TITLE
feat: implement container image vulnerability scanning

### DIFF
--- a/k8s/apps/argocd/applications/security-policies-app.yaml
+++ b/k8s/apps/argocd/applications/security-policies-app.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: security-policies
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    app.kubernetes.io/name: security-policies
+    app.kubernetes.io/part-of: homelab
+    app.kubernetes.io/component: infrastructure
+    app.kubernetes.io/managed-by: argocd
+spec:
+  project: apps
+  source:
+    repoURL: git@github.com:holdennguyen/homelab.git
+    targetRevision: HEAD
+    path: k8s/apps/security/policies
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false

--- a/k8s/apps/argocd/applications/trivy-operator-app.yaml
+++ b/k8s/apps/argocd/applications/trivy-operator-app.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trivy-operator
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: trivy-operator
+    app.kubernetes.io/part-of: homelab
+    app.kubernetes.io/component: security
+    app.kubernetes.io/managed-by: argocd
+spec:
+  project: apps
+  source:
+    repoURL: https://aquasecurity.github.io/trivy-operator/
+    chart: trivy-operator
+    targetRevision: "0.21.0"
+    helm:
+      valuesObject:
+        trivy:
+          # Scan running pods periodically
+          scanJobs:
+            enabled: true
+          # Ignore unfixed vulnerabilities (optional, reduce noise)
+          ignoreUnfixed: true
+          severity: HIGH,CRITICAL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: security
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/apps/argocd/kustomization.yaml
+++ b/k8s/apps/argocd/kustomization.yaml
@@ -20,3 +20,5 @@ resources:
   - applications/authentik-app.yaml
   - applications/authentik-config-app.yaml
   - applications/openclaw-app.yaml
+  - applications/trivy-operator-app.yaml
+  - applications/security-policies-app.yaml

--- a/k8s/apps/argocd/projects/apps.yaml
+++ b/k8s/apps/argocd/projects/apps.yaml
@@ -11,6 +11,7 @@ spec:
     - git@github.com:holdennguyen/homelab.git
     - https://prometheus-community.github.io/helm-charts
     - https://charts.goauthentik.io
+    - https://aquasecurity.github.io/trivy-operator/
   destinations:
     - server: https://kubernetes.default.svc
       namespace: gitea-system
@@ -22,6 +23,8 @@ spec:
       namespace: openclaw
     - server: https://kubernetes.default.svc
       namespace: authentik
+    - server: https://kubernetes.default.svc
+      namespace: security
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/k8s/apps/security/README.md
+++ b/k8s/apps/security/README.md
@@ -1,0 +1,41 @@
+# Security - Trivy Operator
+
+This directory contains the ArgoCD application and network policies for the `security` namespace, which hosts the Trivy Operator.
+
+## Trivy Operator
+
+Trivy Operator provides continuous container image vulnerability scanning for Kubernetes workloads. It periodically scans images of running pods and creates `VulnerabilityReport` custom resources that can be viewed via `kubectl` or integrated with monitoring.
+
+**Key features:**
+
+- Scans images of running pods automatically.
+- Generates `VulnerabilityReport` CRs in the same namespace as the scanned pod.
+- Can optionally block deployments of images with critical vulnerabilities when used as an admission controller (not enabled in this setup).
+- Supports configurable severity thresholds and resource limits.
+
+**Deployment:** Managed via the `trivy-operator` Helm chart from the Aquasecurity repository.
+
+**Network Policies:** The `security` namespace uses default-deny with specific egress rules to allow:
+- DNS resolution (UDP/TCP 53) to `kube-system`.
+- Egress to Kubernetes API server (TCP 6443).
+- Egress to container registries over HTTPS (TCP 443).
+- Intra-namespace communication.
+
+See [`docs/networking.md`](../../docs/networking.md) for the full traffic matrix.
+
+## Resources
+
+| File | Purpose |
+|------|---------|
+| `policies/` | NetworkPolicy definitions for the `security` namespace |
+| `trivy-operator-app.yaml` (in `k8s/apps/argocd/applications/`) | ArgoCD Application that installs Trivy Operator via Helm |
+
+## Accessing Vulnerability Reports
+
+```bash
+# List all VulnerabilityReports in a namespace
+kubectl get vulnerabilityreports -n <namespace>
+
+# View a specific report
+kubectl get vulnerabilityreport <pod-name> -n <namespace> -o yaml
+```

--- a/k8s/apps/security/policies/00-allow-dns-egress.yaml
+++ b/k8s/apps/security/policies/00-allow-dns-egress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: security
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53

--- a/k8s/apps/security/policies/01-allow-intra-namespace.yaml
+++ b/k8s/apps/security/policies/01-allow-intra-namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: security
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector: {}
+  egress:
+  - to:
+    - podSelector: {}

--- a/k8s/apps/security/policies/02-allow-egress-api.yaml
+++ b/k8s/apps/security/policies/02-allow-egress-api.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-api
+  namespace: security
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: TCP
+      port: 6443

--- a/k8s/apps/security/policies/03-allow-egress-https.yaml
+++ b/k8s/apps/security/policies/03-allow-egress-https.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-https
+  namespace: security
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 443

--- a/k8s/apps/security/policies/99-default-deny-all.yaml
+++ b/k8s/apps/security/policies/99-default-deny-all.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: security
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/k8s/apps/security/policies/kustomization.yaml
+++ b/k8s/apps/security/policies/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - 00-allow-dns-egress.yaml
+  - 01-allow-intra-namespace.yaml
+  - 02-allow-egress-api.yaml
+  - 03-allow-egress-https.yaml
+  - 99-default-deny-all.yaml


### PR DESCRIPTION
Closes #5\n\n## Summary\n- Deployed Trivy Operator to the `security` namespace via Helm chart from Aquasecurity.\n- Added network policies for the `security` namespace to allow DNS, API server access, and HTTPS egress to registries.\n- Created dedicated ArgoCD Applications: `trivy-operator-app` (Helm release) and `security-policies` (NetworkPolicies).\n- Added `security` namespace to `apps` project destinations and Aquasecurity Helm repo to sourceRepos.\n- Updated documentation: new `k8s/apps/security/README.md` describes the setup and policies.\n\n## Test plan\n- [ ] ArgoCD syncs successfully for `trivy-operator` and `security-policies` Applications.\n- [ ] Trivy Operator pods become healthy in `security` namespace.\n- [ ] VulnerabilityReport CRs appear after pod scans (check `kubectl get vulnerabilityreports -A`).\n- [ ] Network Policies correctly restrict egress (no blocked DNS, API, registry access).\n- [ ] Scans detect vulnerabilities on existing images (e.g., `kubectl get vulnerabilityreport <pod> -n <ns>`).\n\n## Notes\n- Trivy Operator runs with default scan settings except: `ignoreUnfixed=true`, severity focus on HIGH/CRITICAL, and resource limits to protect homelab resources.\n- The `security` namespace policies are applied with a sync-wave of 1 to ensure the namespace exists first.\n\n---\nAgent: homelab-admin | OpenClaw Homelab