### PR TITLE
security: scope down openclaw service account permissions

### DIFF
--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -60,7 +60,7 @@ flowchart TD
 | `configmap.yaml` | Multi-agent `openclaw.json` config (gateway, agents, skills, tools) |
 | `deployment.yaml` | Single-replica deployment with config/skills/workspace volumes |
 | `service.yaml` | NodePort service exposing port 30789 |
-| `rbac.yaml` | ServiceAccount + ClusterRoleBinding (cluster-admin) |
+| `rbac.yaml` | ServiceAccount (openclaw), Role (self-namespace full access), RoleBinding, ClusterRole (cluster-wide read-only + exec/log), ClusterRoleBinding (read-only) |
 | `kustomization.yaml` | Kustomize resource list |
 
 Related files outside this directory:
@@ -527,7 +527,10 @@ When the primary model fails, OpenClaw automatically falls through to Gemini. Au
 
 Agent configuration is in the `openclaw-config` ConfigMap (mounted at `/config/openclaw.json`). Each agent has its own AGENTS.md personality file in `agents/workspaces/<id>/AGENTS.md`, copied into the pod workspace on every restart by the `init-workspaces` init container.
 
-The pod runs with a `cluster-admin` ServiceAccount so agents can execute `kubectl`, `helm`, and other ops tools against the cluster directly.
+The pod uses the `openclaw` ServiceAccount, which has been scoped down from cluster-admin to:
+- Full access within the `openclaw` namespace (via Role).
+- Read-only access to most Kubernetes resources across the cluster, plus the ability to view pod logs and exec into pods (via ClusterRole and ClusterRoleBinding).
+This follows the principle of least privilege.
 
 ### Skills
 

--- a/k8s/apps/openclaw/kustomization.yaml
+++ b/k8s/apps/openclaw/kustomization.yaml
@@ -6,5 +6,9 @@ resources:
   - external-secret.yaml
   - configmap.yaml
   - rbac.yaml
+  - openclaw-self-role.yaml
+  - openclaw-self-rolebinding.yaml
+  - openclaw-read-only-clusterrole.yaml
+  - openclaw-read-only-clusterrolebinding.yaml
   - deployment.yaml
   - service.yaml

--- a/k8s/apps/openclaw/openclaw-read-only-clusterrole.yaml
+++ b/k8s/apps/openclaw/openclaw-read-only-clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openclaw-read-only
+  labels:
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/instance: openclaw
+rules:
+# Core resources (namespaced and cluster-scoped)
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+# Subresources
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]

--- a/k8s/apps/openclaw/openclaw-read-only-clusterrolebinding.yaml
+++ b/k8s/apps/openclaw/openclaw-read-only-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openclaw-read-only-binding
+  labels:
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/instance: openclaw
+subjects:
+- kind: ServiceAccount
+  name: openclaw
+  namespace: openclaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openclaw-read-only

--- a/k8s/apps/openclaw/openclaw-self-role.yaml
+++ b/k8s/apps/openclaw/openclaw-self-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openclaw-self
+  namespace: openclaw
+  labels:
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/instance: openclaw
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]

--- a/k8s/apps/openclaw/openclaw-self-rolebinding.yaml
+++ b/k8s/apps/openclaw/openclaw-self-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openclaw-self-binding
+  namespace: openclaw
+  labels:
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/instance: openclaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openclaw-self
+subjects:
+- kind: ServiceAccount
+  name: openclaw
+  namespace: openclaw

--- a/k8s/apps/openclaw/rbac.yaml
+++ b/k8s/apps/openclaw/rbac.yaml
@@ -6,19 +6,3 @@ metadata:
   labels:
     app.kubernetes.io/name: openclaw
     app.kubernetes.io/instance: openclaw
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: openclaw-cluster-admin
-  labels:
-    app.kubernetes.io/name: openclaw
-    app.kubernetes.io/instance: openclaw
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: openclaw
-    namespace: openclaw


### PR DESCRIPTION
Closes #3\n\n## Summary\n- Removed the `ClusterRoleBinding` granting `cluster-admin` to the `openclaw` ServiceAccount.\n- Introduced scoped-down permissions:\n  - A `Role` in the `openclaw` namespace (`openclaw-self`) provides full access within its own namespace (required for self-management).\n  - A `ClusterRole` (`openclaw-read-only`) grants read-only access (`get`, `list`, `watch`) to all Kubernetes resources cluster-wide, plus the ability to fetch pod logs and create exec sessions.\n  - Corresponding `RoleBinding` and `ClusterRoleBinding` link the ServiceAccount to these roles.\n- This follows least privilege: no cluster-admin rights, no write access outside its namespace, while still enabling agents to inspect cluster state and perform troubleshooting via `kubectl`.\n\n## Test plan\n- [ ] ArgoCD syncs successfully; no failing health checks.\n- [ ] `openclaw` pod starts and functions correctly.\n- [ ] Service health verified.\n- [ ] Agents can read resources from other namespaces (e.g., `kubectl get pods -A`).\n- [ ] Agents can fetch pod logs and exec into pods.\n- [ ] Agents cannot modify resources outside `openclaw` namespace (attempt to delete should fail with Forbidden).\n- [ ] ExternalSecret `openclaw-secret` syncs successfully.\n- [ ] Git ops (issue creation, PR creation) still function.\n\n## Documentation\n- Updated `k8s/apps/openclaw/README.md` to reflect the new RBAC setup.\n\n---\nAgent: homelab-admin | OpenClaw Homelab