### PR TITLE
feat: require issue-first planning before implementation

### DIFF
--- a/.cursor/rules/homelab.mdc
+++ b/.cursor/rules/homelab.mdc
@@ -27,16 +27,49 @@ This is a GitOps-driven homelab running on a Mac mini M4 with OrbStack Kubernete
 
 The `main` branch is **protected**. Never push directly to `main` — all changes require a feature branch and a pull request. This applies to Cursor just as it applies to OpenClaw agents.
 
+### Issue-First Planning (mandatory)
+
+When addressing a GitHub issue (whether assigned by a user, picked from the backlog, or self-created), **always plan before coding**:
+
+1. **Read the issue** — understand the requirements, acceptance criteria, and linked context
+2. **Draft an implementation plan** covering:
+   - Which files/services will be modified
+   - The approach and key design decisions
+   - Risks, dependencies, or open questions
+   - Docs that need updating (check the documentation matrix below)
+3. **Comment the plan on the issue** using `gh issue comment`:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   ## Implementation Plan
+
+   **Approach:** <high-level summary>
+
+   **Files to change:**
+   - `<path>` — <what and why>
+
+   **Risks / open questions:**
+   - <any concerns>
+
+   **Docs to update:**
+   - <list from documentation matrix>
+   EOF
+   )"
+   ```
+4. **Wait for feedback** if the plan is non-trivial or the issue was filed by someone else — proceed immediately only for straightforward changes you filed yourself
+5. **Reference the plan** throughout implementation — commit messages and PR body should trace back to the plan
+
+This ensures every change is deliberate, reviewable, and traceable. Jumping straight to code without a plan leads to missed requirements and wasted review cycles.
+
 ### Branch workflow
 
 1. **Start from latest main:**
-   ```bash
-   git checkout main && git pull origin main
-   git checkout -b <type>/<short-description>
-   ```
-   Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `security/`
+ ```bash
+ git checkout main && git pull origin main
+ git checkout -b <type>/<short-description>
+ ```
+ Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `security/`
 
-2. **Make changes** and commit with conventional messages:
+2. **Make changes** (referencing the plan from the issue) and commit with conventional messages:
    ```bash
    git add <files>
    git commit -m "<type>: <description>"

--- a/agents/workspaces/devops-sre/AGENTS.md
+++ b/agents/workspaces/devops-sre/AGENTS.md
@@ -60,22 +60,45 @@ git config user.email "devops-sre@openclaw.homelab"
    ```
    If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
 
-2. **Create a branch** from latest main:
+2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   ## Implementation Plan
+
+   **Approach:** <high-level summary>
+
+   **Files to change:**
+   - `<path>` — <what and why>
+
+   **Risks / open questions:**
+   - <any concerns>
+
+   **Docs to update:**
+   - <list from documentation matrix>
+
+   ---
+   Agent: devops-sre | OpenClaw Homelab
+   EOF
+   )"
+   ```
+   The plan must cover: files/services to change, approach, risks, and docs to update. For non-trivial changes or issues filed by someone else, wait for feedback before proceeding.
+
+3. **Create a branch** from latest main:
    ```bash
    git checkout main && git pull origin main
    git checkout -b devops-sre/<type>/<issue-number>-<short-description>
    ```
    Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`
 
-3. **Make changes** to the appropriate files (manifests, config, terraform, docs)
+4. **Make changes** to the appropriate files (manifests, config, terraform, docs), referencing the plan from step 2
 
-4. **Commit** with a descriptive message referencing the issue and agent tag:
+5. **Commit** with a descriptive message referencing the issue and agent tag:
    ```bash
    git add <files>
    git commit -m "<type>: <description> (#<issue-number>) [devops-sre]"
    ```
 
-5. **Push and create a labeled PR** assigned to the same milestone:
+6. **Push and create a labeled PR** assigned to the same milestone. Reference the implementation plan:
    ```bash
    git push -u origin HEAD
    gh pr create \
@@ -88,6 +111,7 @@ git config user.email "devops-sre@openclaw.homelab"
 
    ## Summary
    - <what changed and why>
+   - Implementation plan: #<issue-number> (comment)
 
    ## Test plan
    - [ ] ArgoCD syncs successfully
@@ -100,7 +124,7 @@ git config user.email "devops-sre@openclaw.homelab"
    )"
    ```
 
-6. **Report the PR URL** back to the orchestrator (or user if working directly)
+7. **Report the PR URL** back to the orchestrator (or user if working directly)
 
 ### Label reference
 

--- a/agents/workspaces/homelab-admin/AGENTS.md
+++ b/agents/workspaces/homelab-admin/AGENTS.md
@@ -42,7 +42,7 @@ When a user requests a change that modifies the homelab repository:
 1. **Analyze** the request — determine the scope and which agent should handle it
 2. **Determine labels** — pick the right type, area, and priority labels for the task
 3. **Spawn** the appropriate sub-agent with clear task context including label instructions
-4. The sub-agent follows the mandatory git workflow (issue → branch → changes → commit → PR)
+4. The sub-agent follows the mandatory git workflow (issue → **plan on issue** → branch → changes → commit → PR)
 5. **Relay** the PR URL and summary back to the user
 6. **Explain** next steps: "Once merged to `main`, ArgoCD syncs within ~3 minutes"
 
@@ -82,22 +82,45 @@ git config user.email "homelab-admin@openclaw.homelab"
    ```
    If no open milestone exists, create one (see [Release Management](#release-management)).
 
-2. **Create a branch** from latest main:
+2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   ## Implementation Plan
+
+   **Approach:** <high-level summary>
+
+   **Files to change:**
+   - `<path>` — <what and why>
+
+   **Risks / open questions:**
+   - <any concerns>
+
+   **Docs to update:**
+   - <list from documentation matrix>
+
+   ---
+   Agent: homelab-admin | OpenClaw Homelab
+   EOF
+   )"
+   ```
+   The plan must cover: files/services to change, approach, risks, and docs to update. For non-trivial changes or issues filed by someone else, wait for feedback before proceeding.
+
+3. **Create a branch** from latest main:
    ```bash
    git checkout main && git pull origin main
    git checkout -b homelab-admin/<type>/<issue-number>-<short-description>
    ```
    Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`
 
-3. **Make changes** to the appropriate files (manifests, config, terraform, docs)
+4. **Make changes** to the appropriate files (manifests, config, terraform, docs), referencing the plan from step 2
 
-4. **Commit** with a descriptive message referencing the issue and agent tag:
+5. **Commit** with a descriptive message referencing the issue and agent tag:
    ```bash
    git add <files>
    git commit -m "<type>: <description> (#<issue-number>) [homelab-admin]"
    ```
 
-5. **Push and create a labeled PR** assigned to the same milestone:
+6. **Push and create a labeled PR** assigned to the same milestone. Reference the implementation plan:
    ```bash
    git push -u origin HEAD
    gh pr create \
@@ -110,6 +133,7 @@ git config user.email "homelab-admin@openclaw.homelab"
 
    ## Summary
    - <what changed and why>
+   - Implementation plan: #<issue-number> (comment)
 
    ## Test plan
    - [ ] ArgoCD syncs successfully
@@ -122,7 +146,7 @@ git config user.email "homelab-admin@openclaw.homelab"
    )"
    ```
 
-6. **Report the PR URL** back to the user
+7. **Report the PR URL** back to the user
 
 ### Label reference
 

--- a/agents/workspaces/qa-tester/AGENTS.md
+++ b/agents/workspaces/qa-tester/AGENTS.md
@@ -126,22 +126,45 @@ git config user.email "qa-tester@openclaw.homelab"
    ```
    If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
 
-2. **Create a branch** from latest main:
+2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   ## Implementation Plan
+
+   **Approach:** <high-level summary>
+
+   **Files to change:**
+   - `<path>` — <what and why>
+
+   **Risks / open questions:**
+   - <any concerns>
+
+   **Docs to update:**
+   - <list from documentation matrix>
+
+   ---
+   Agent: qa-tester | OpenClaw Homelab
+   EOF
+   )"
+   ```
+   The plan must cover: files/services to change, approach, risks, and docs to update. For non-trivial changes or issues filed by someone else, wait for feedback before proceeding.
+
+3. **Create a branch** from latest main:
    ```bash
    git checkout main && git pull origin main
    git checkout -b qa-tester/<type>/<issue-number>-<short-description>
    ```
    Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`
 
-3. **Make changes** — add test checklists, fix manifest issues found during testing, update docs
+4. **Make changes** — add test checklists, fix manifest issues found during testing, update docs, referencing the plan from step 2
 
-4. **Commit** with a descriptive message referencing the issue and agent tag:
+5. **Commit** with a descriptive message referencing the issue and agent tag:
    ```bash
    git add <files>
    git commit -m "<type>: <description> (#<issue-number>) [qa-tester]"
    ```
 
-5. **Push and create a labeled PR** assigned to the same milestone:
+6. **Push and create a labeled PR** assigned to the same milestone. Reference the implementation plan:
    ```bash
    git push -u origin HEAD
    gh pr create \
@@ -154,6 +177,7 @@ git config user.email "qa-tester@openclaw.homelab"
 
    ## Summary
    - <what changed and why>
+   - Implementation plan: #<issue-number> (comment)
 
    ## Test Evidence
    - <pass/fail results with commands and output>
@@ -165,7 +189,7 @@ git config user.email "qa-tester@openclaw.homelab"
    )"
    ```
 
-6. **Report the PR URL** back to the orchestrator (or user if working directly)
+7. **Report the PR URL** back to the orchestrator (or user if working directly)
 
 ### Label reference
 

--- a/agents/workspaces/security-analyst/AGENTS.md
+++ b/agents/workspaces/security-analyst/AGENTS.md
@@ -60,22 +60,45 @@ git config user.email "security-analyst@openclaw.homelab"
    ```
    If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
 
-2. **Create a branch** from latest main:
+2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   ## Implementation Plan
+
+   **Approach:** <high-level summary>
+
+   **Files to change:**
+   - `<path>` — <what and why>
+
+   **Risks / open questions:**
+   - <any concerns>
+
+   **Docs to update:**
+   - <list from documentation matrix>
+
+   ---
+   Agent: security-analyst | OpenClaw Homelab
+   EOF
+   )"
+   ```
+   The plan must cover: files/services to change, approach, risks, and docs to update. For non-trivial changes or issues filed by someone else, wait for feedback before proceeding.
+
+3. **Create a branch** from latest main:
    ```bash
    git checkout main && git pull origin main
    git checkout -b security-analyst/<type>/<issue-number>-<short-description>
    ```
    Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`
 
-3. **Make changes** — apply hardening, fix vulnerabilities, update policies
+4. **Make changes** — apply hardening, fix vulnerabilities, update policies, referencing the plan from step 2
 
-4. **Commit** with a descriptive message referencing the issue and agent tag:
+5. **Commit** with a descriptive message referencing the issue and agent tag:
    ```bash
    git add <files>
    git commit -m "<type>: <description> (#<issue-number>) [security-analyst]"
    ```
 
-5. **Push and create a labeled PR** assigned to the same milestone:
+6. **Push and create a labeled PR** assigned to the same milestone. Reference the implementation plan:
    ```bash
    git push -u origin HEAD
    gh pr create \
@@ -89,6 +112,7 @@ git config user.email "security-analyst@openclaw.homelab"
    ## Summary
    - <what changed and why>
    - **Severity:** <critical|high|medium|low>
+   - Implementation plan: #<issue-number> (comment)
 
    ## Test plan
    - [ ] No secrets exposed in diff
@@ -102,7 +126,7 @@ git config user.email "security-analyst@openclaw.homelab"
    )"
    ```
 
-6. **Report the PR URL** back to the orchestrator (or user if working directly)
+7. **Report the PR URL** back to the orchestrator (or user if working directly)
 
 ### Label reference
 

--- a/agents/workspaces/software-engineer/AGENTS.md
+++ b/agents/workspaces/software-engineer/AGENTS.md
@@ -51,22 +51,45 @@ git config user.email "software-engineer@openclaw.homelab"
    ```
    If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
 
-2. **Create a branch** from latest main:
+2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   ## Implementation Plan
+
+   **Approach:** <high-level summary>
+
+   **Files to change:**
+   - `<path>` — <what and why>
+
+   **Risks / open questions:**
+   - <any concerns>
+
+   **Docs to update:**
+   - <list from documentation matrix>
+
+   ---
+   Agent: software-engineer | OpenClaw Homelab
+   EOF
+   )"
+   ```
+   The plan must cover: files/services to change, approach, risks, and docs to update. For non-trivial changes or issues filed by someone else, wait for feedback before proceeding.
+
+3. **Create a branch** from latest main:
    ```bash
    git checkout main && git pull origin main
    git checkout -b software-engineer/<type>/<issue-number>-<short-description>
    ```
    Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`
 
-3. **Make changes** — implement with tests alongside feature code
+4. **Make changes** — implement with tests alongside feature code, referencing the plan from step 2
 
-4. **Commit** with a descriptive message referencing the issue and agent tag:
+5. **Commit** with a descriptive message referencing the issue and agent tag:
    ```bash
    git add <files>
    git commit -m "<type>: <description> (#<issue-number>) [software-engineer]"
    ```
 
-5. **Push and create a labeled PR** assigned to the same milestone:
+6. **Push and create a labeled PR** assigned to the same milestone. Reference the implementation plan:
    ```bash
    git push -u origin HEAD
    gh pr create \
@@ -79,6 +102,7 @@ git config user.email "software-engineer@openclaw.homelab"
 
    ## Summary
    - <what changed and why>
+   - Implementation plan: #<issue-number> (comment)
 
    ## Test plan
    - [ ] Tests pass
@@ -91,7 +115,7 @@ git config user.email "software-engineer@openclaw.homelab"
    )"
    ```
 
-6. **Report the PR URL** back to the orchestrator (or user if working directly)
+7. **Report the PR URL** back to the orchestrator (or user if working directly)
 
 ### Label reference
 

--- a/skills/gitops/SKILL.md
+++ b/skills/gitops/SKILL.md
@@ -144,7 +144,7 @@ Example: `devops-sre/feat/42-redis-caching`
 
 ### Step-by-step process
 
-1. **Create a GitHub issue** — every change starts with a labeled issue assigned to the current milestone:
+1. **Create a GitHub issue** (or receive an existing one) — every change starts with a labeled issue assigned to the current milestone:
    ```bash
    gh issue create \
      --title "<type>: <description>" \
@@ -162,7 +162,30 @@ Example: `devops-sre/feat/42-redis-caching`
    ```
    Capture the issue number from the output. If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
 
-2. **Create a branch** from latest main:
+2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan as a comment:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   ## Implementation Plan
+
+   **Approach:** <high-level summary of what you'll do>
+
+   **Files to change:**
+   - `<path>` — <what and why>
+
+   **Risks / open questions:**
+   - <anything that could go wrong or needs clarification>
+
+   **Docs to update:**
+   - <list from the documentation matrix>
+
+   ---
+   Agent: <your-agent-id> | OpenClaw Homelab
+   EOF
+   )"
+   ```
+   The plan must cover: which files/services change, the approach and key decisions, risks or dependencies, and which docs need updating. For non-trivial changes or issues filed by someone else, wait for feedback before proceeding. For straightforward changes you filed yourself, proceed immediately after posting the plan.
+
+3. **Create a branch** from latest main:
    ```bash
    git checkout main && git pull origin main
    git checkout -b <your-agent-id>/<type>/<issue-number>-<short-description>
@@ -177,19 +200,19 @@ Example: `devops-sre/feat/42-redis-caching`
    | `docs/` | Documentation-only changes |
    | `refactor/` | Restructuring without behavior change |
 
-3. **Make changes** to the appropriate files:
+4. **Make changes** to the appropriate files, referencing the plan from step 2:
    - Kubernetes manifests: `k8s/apps/<service>/`
    - ArgoCD applications: `k8s/apps/argocd/applications/`
    - Terraform (Layer 0): `terraform/`
    - Documentation: `k8s/apps/<service>/README.md` (single source of truth)
 
-4. **Commit** referencing the issue with agent tag:
+5. **Commit** referencing the issue with agent tag:
    ```bash
    git add <files>
    git commit -m "<type>: <description> (#<issue-number>) [<your-agent-id>]"
    ```
 
-5. **Push and create a labeled PR** assigned to the same milestone as the issue:
+6. **Push and create a labeled PR** assigned to the same milestone as the issue. Reference the implementation plan from the issue:
    ```bash
    git push -u origin HEAD
    gh pr create \
@@ -202,6 +225,7 @@ Example: `devops-sre/feat/42-redis-caching`
 
    ## Summary
    - <bullet points: what changed and why>
+   - Implementation plan: #<issue-number> (comment)
 
    ## Test plan
    - [ ] ArgoCD syncs successfully
@@ -214,7 +238,7 @@ Example: `devops-sre/feat/42-redis-caching`
    )"
    ```
 
-6. **Report** the PR URL to the user or orchestrator agent.
+7. **Report** the PR URL to the user or orchestrator agent.
 
 ### After merge
 


### PR DESCRIPTION
## Summary

- Adds a mandatory "Issue-First Planning" step to the git workflow for both Cursor (`.cursor/rules/homelab.mdc`) and all OpenClaw agents
- Before writing any code, agents must post an implementation plan as a comment on the GitHub issue covering: approach, files to change, risks/open questions, and docs to update
- PR bodies now include a reference back to the implementation plan comment on the issue
- Step numbering updated across all 5 agent `AGENTS.md` files and `skills/gitops/SKILL.md`

## Files changed

| File | Change |
|---|---|
| `.cursor/rules/homelab.mdc` | New "Issue-First Planning (mandatory)" section in Cursor workflow |
| `skills/gitops/SKILL.md` | New step 2 (plan + comment) in the shared step-by-step process |
| `agents/workspaces/homelab-admin/AGENTS.md` | New step 2 + updated delegation flow |
| `agents/workspaces/software-engineer/AGENTS.md` | New step 2 |
| `agents/workspaces/devops-sre/AGENTS.md` | New step 2 |
| `agents/workspaces/security-analyst/AGENTS.md` | New step 2 |
| `agents/workspaces/qa-tester/AGENTS.md` | New step 2 |

## Test plan

- [x] Cursor rule loads correctly (verify `.cursor/rules/homelab.mdc` parses)
- [x] OpenClaw agents pick up updated AGENTS.md on next restart
- [x] Skill file is valid markdown with correct frontmatter

Made with [Cursor](https://cursor.com)