### PR TITLE
fix: stabilize trivy-operator with resource/concurrency tuning

### DIFF
--- a/k8s/apps/argocd/applications/trivy-operator-app.yaml
+++ b/k8s/apps/argocd/applications/trivy-operator-app.yaml
@@ -18,13 +18,24 @@ spec:
     targetRevision: 0.32.0
     helm:
       valuesObject:
+        excludeNamespaces: "openclaw"
+        operator:
+          scanJobsConcurrentLimit: 3
+        trivy:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100M
+            limits:
+              cpu: 500m
+              memory: 1Gi
         resources:
           requests:
-            cpu: 50m
-            memory: 128Mi
-          limits:
-            cpu: 200m
+            cpu: 100m
             memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring

--- a/k8s/apps/trivy-operator/README.md
+++ b/k8s/apps/trivy-operator/README.md
@@ -28,21 +28,29 @@ flowchart TD
 
 ## Configuration
 
-The operator is deployed with default settings, which:
+The operator is deployed with tuned settings to balance scanning coverage with resource stability on a single-node homelab:
 
-- Scan images of running pods
-- Scan on pod creation and at regular intervals
-- Do not block pod scheduling (report-only)
-- Store reports as Kubernetes custom resources
+- Scans images of running pods on creation and at regular intervals
+- Does not block pod scheduling (report-only)
+- Stores reports as Kubernetes custom resources
+- Excludes the `openclaw` namespace (locally-built image not available from any registry)
+- Limits concurrent scan jobs to 3 to avoid Trivy cache lock contention
 
 ### Helm Values
 
-Overrides can be made in the Application CR's `spec.source.helm.valuesObject`.
+Overrides are set in the Application CR's `spec.source.helm.valuesObject`:
 
-Key options:
-- `resources`: CPU/memory requests/limits for the operator deployment
-- `trivy.ignoreUnfixed`: whether to ignore vulnerabilities without a fix
+| Key | Value | Purpose |
+|-----|-------|---------|
+| `resources.limits.memory` | `512Mi` | Operator deployment — prevents OOM on large clusters |
+| `resources.requests.memory` | `256Mi` | Operator deployment baseline |
+| `operator.scanJobsConcurrentLimit` | `3` | Prevents cache lock contention between parallel scan jobs |
+| `trivy.resources.limits.memory` | `1Gi` | Scan job containers — large images need more memory |
+| `excludeNamespaces` | `openclaw` | Skip namespaces with local-only images |
+
+Additional options:
 - `trivy.severity`: filter by severity (e.g., `HIGH`, `CRITICAL`)
+- `trivy.ignoreUnfixed`: whether to ignore vulnerabilities without a fix
 
 Refer to the [Trivy Operator documentation](https://github.com/aquasecurity/trivy-operator) for advanced configuration.
 
@@ -75,4 +83,7 @@ kubectl delete vulnerabilityreport --all -n <namespace>
 |---------|-------|-----|
 | No VulnerabilityReport CRs appear | Operator not running or RBAC issues | Check pod logs: `kubectl logs -n monitoring -l app.kubernetes.io/name=trivy-operator` |
 | Reports show `FAILED` | Image scan failed (private registry, large image, timeout) | Verify image pull secret exists; consider increasing resources/timeouts |
-| High CPU/Memory usage | Scanning many large images | Adjust operator resources; consider increasing limits |
+| Operator OOMKilled (exit 137) | Too many workloads to reconcile | Increase `resources.limits.memory` in Helm values |
+| "cache may be in use by another process" | Concurrent scan jobs contending on Trivy cache | Reduce `operator.scanJobsConcurrentLimit` (default 10) |
+| Scan job OOMKilled | Large container image exceeds scan job memory | Increase `trivy.resources.limits.memory` |
+| "unable to find the specified image" | Local-only image not in any registry | Add namespace to `excludeNamespaces` |


### PR DESCRIPTION
## Summary

- Increase operator deployment memory from 256Mi→512Mi (was OOMKilled with exit code 137 after 3 restarts)
- Reduce `scanJobsConcurrentLimit` from 10→3 to prevent Trivy cache lock contention (`cache may be in use by another process: timeout`)
- Increase scan job memory limit to 1Gi (scan pods OOMKilled on large images like Grafana)
- Exclude `openclaw` namespace from scanning (locally-built `openclaw:latest` image is not available from any registry)
- Update trivy-operator README with configuration table and troubleshooting entries

## Root Cause Analysis

| Issue | Symptom | Root Cause |
|-------|---------|------------|
| Operator restarts (3 in 12min) | Exit code 137, readiness probe timeout | 256Mi memory limit too low |
| Scan failures | `cache may be in use by another process` | 10 concurrent scan jobs sharing Trivy cache via emptyDir |
| Scan failures | `OOMKilled` on scan pods | Default 500M limit insufficient for large multi-layer images |
| Scan failures | `unable to find the specified image "openclaw:latest"` | Local-only image, no Docker/containerd socket accessible |

## Test plan

- [ ] Verify operator pod no longer OOMKilled (no restarts after sync)
- [ ] Verify scan jobs complete without cache lock errors
- [ ] Verify VulnerabilityReports are generated for scanned namespaces
- [ ] Verify openclaw namespace is excluded from scanning


Made with [Cursor](https://cursor.com)