### PR TITLE
docs: root README strategy — update, narrow tracking, and release gate

### DIFF
--- a/.cursor/rules/homelab.mdc
+++ b/.cursor/rules/homelab.mdc
@@ -124,6 +124,22 @@ Before merging PRs that modify cluster resources:
 - Check container image compatibility with `securityContext` changes
 - Review ArgoCD sync wave dependencies
 
+### Release checklist
+
+Before tagging a new release (e.g. `v1.1.0`), complete every item:
+
+1. **All milestone PRs merged** — no open PRs targeting this release
+2. **ArgoCD health** — all applications `Synced` + `Healthy` (`kubectl get applications -n argocd`)
+3. **Doc freshness** — run `python scripts/doc-freshness.py` and resolve any stale entries
+4. **Root README review** — the root `README.md` is the public face of the repo. It is tracked in `.doc-manifest.yml` with narrow sources (kustomization.yaml, mkdocs.yml), but those triggers only catch structural additions. Manually review and update:
+   - Architecture diagram — does it reflect all current namespaces and services?
+   - Repository structure — any new top-level directories or service directories?
+   - Deployed services table — any new services, changed ports, or removed services?
+   - Documentation index — does the table list every doc file?
+   - Quick Start / secrets table — any new secrets or changed bootstrap steps?
+   - Future Plans — move completed items out, add new plans
+5. **Tag and release** — `git tag -a vX.Y.Z -m "release description" && git push origin vX.Y.Z`
+
 ## Documentation Rule (mandatory)
 
 After every implementation, update the related documentation before considering the task complete. This is not optional.
@@ -179,6 +195,7 @@ Every `k8s/apps/<service>/README.md` should include these sections (adapt as nee
 | Secrets pipeline (ExternalSecret, Infisical) | `docs/secret-management.md` |
 | Networking (Tailscale, services, ports) | `docs/networking.md` |
 | New service added | See "Adding a new service" checklist below |
+| **Release milestone** | Review and update root `README.md` (see release checklist above) |
 
 ### Adding a new service (documentation checklist)
 
@@ -187,8 +204,9 @@ Every `k8s/apps/<service>/README.md` should include these sections (adapt as nee
 3. Add `<service>.md` to the `nav` in `mkdocs.yml`
 4. Add doc → source mapping to `.doc-manifest.yml`
 5. Update the service map and repository layout in `docs/architecture.md`
-6. If the service has secrets, update `docs/secret-management.md` and `k8s/apps/infisical/README.md` inventory
-7. If the service has a Tailscale endpoint, update `docs/networking.md` and `docs/bootstrap.md` (Tailscale Serve commands)
+6. Update root `README.md` — architecture diagram, repository structure, deployed services table, and documentation index
+7. If the service has secrets, update `docs/secret-management.md` and `k8s/apps/infisical/README.md` inventory
+8. If the service has a Tailscale endpoint, update `docs/networking.md` and `docs/bootstrap.md` (Tailscale Serve commands)
 
 ### Rules
 

--- a/.doc-manifest.yml
+++ b/.doc-manifest.yml
@@ -15,6 +15,14 @@
 #   - When adding a new service, add its README entry here
 
 documents:
+  # ── Root README (high-level overview) ──
+  # Narrow sources: only structural files that indicate a new service or doc was added.
+  # Full review of the root README is enforced at release time (see homelab.mdc release checklist).
+  - doc: README.md
+    sources:
+      - k8s/apps/argocd/kustomization.yaml
+      - mkdocs.yml
+
   # ── Service READMEs (single source of truth per service) ──
   - doc: k8s/apps/argocd/README.md
     sources:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homelab
 
-A GitOps-managed Kubernetes homelab running on OrbStack (Mac mini M4). Deploys self-hosted infrastructure services -- Authentik SSO, Gitea, PostgreSQL, Grafana + Prometheus, Infisical, and OpenClaw AI gateway -- orchestrated by Argo CD, with AI agent skill definitions for multi-agent development workflows. All services are accessible from any device on the Tailscale network (iPhone, iPad, Mac).
+A GitOps-managed Kubernetes homelab running on OrbStack (Mac mini M4). Deploys self-hosted infrastructure services -- Authentik SSO, Gitea, PostgreSQL, Grafana + Prometheus, Infisical, Trivy Operator, and OpenClaw AI gateway -- orchestrated by Argo CD, with security hardening (network policies, Pod Security Standards, non-root execution, vulnerability scanning) and AI agent skill definitions for multi-agent development workflows. All services are accessible from any device on the Tailscale network (iPhone, iPad, Mac).
 
 ## Architecture
 
@@ -20,6 +20,8 @@ flowchart TD
     subgraph orb["OrbStack Kubernetes Cluster"]
         subgraph argocdNs["argocd namespace"]
             ArgoCD["Argo CD\nHelm chart via Terraform\nNodePort :30080"]
+            NsPolicies["Namespace Security\nPod Security Standards"]
+            NetPolicies["Network Policies\nDefault-deny ingress/egress"]
         end
 
         subgraph infisicalNs["infisical namespace"]
@@ -45,6 +47,8 @@ flowchart TD
         subgraph monNs["monitoring namespace"]
             GrafanaPod["Grafana\nNodePort :30090"]
             PromPod["Prometheus"]
+            TrivyOp["Trivy Operator\nClientServer mode"]
+            TrivySrv["Trivy Server\nStatefulSet + PVC"]
         end
 
         subgraph openclawNs["openclaw namespace"]
@@ -63,6 +67,10 @@ flowchart TD
     ArgoCD -- "App of Apps" --> authentikNs
     ArgoCD -- "App of Apps" --> monNs
     ArgoCD -- "App of Apps" --> openclawNs
+    ArgoCD -- "manages" --> NsPolicies
+    ArgoCD -- "manages" --> NetPolicies
+    TrivyOp -->|watches pods| monNs
+    TrivyOp -->|queries| TrivySrv
     ESO --> CSS
     CSS -- "ExternalSecret" --> GiteaPod
     CSS -- "ExternalSecret" --> PostgresPod
@@ -103,8 +111,11 @@ homelab/
 │       ├── infisical/             # (Helm chart managed by Terraform-created Application)
 │       ├── gitea/                 # Gitea kustomize manifests + ExternalSecret
 │       ├── monitoring/            # Grafana ExternalSecret
+│       ├── namespace-security/    # Pod Security Standard labels per namespace
+│       ├── networking-policies/   # Default-deny NetworkPolicy per namespace
 │       ├── openclaw/              # OpenClaw AI gateway kustomize manifests
-│       └── postgresql/            # PostgreSQL kustomize manifests + ExternalSecret
+│       ├── postgresql/            # PostgreSQL kustomize manifests + ExternalSecret
+│       └── trivy-operator/        # Container image vulnerability scanning
 ├── docs/                          # MkDocs documentation site
 ├── agents/                        # OpenClaw agent definitions
 │   ├── root_rules.md              # Shared rules for all agents
@@ -146,9 +157,12 @@ sequenceDiagram
 | Infisical | Helm chart via ArgoCD | `infisical` | `https://holdens-mac-mini.story-larch.ts.net:8445` |
 | External Secrets Operator | Helm chart via ArgoCD | `external-secrets` | internal only |
 | Grafana + Prometheus | Helm chart via ArgoCD | `monitoring` | `https://holdens-mac-mini.story-larch.ts.net:8444` |
+| Trivy Operator | Helm chart via ArgoCD | `monitoring` | internal only (CRs: `kubectl get vulnerabilityreports -A`) |
 | Gitea | Kustomize via ArgoCD | `gitea-system` | `https://holdens-mac-mini.story-larch.ts.net:8446` |
 | PostgreSQL | Kustomize via ArgoCD | `gitea-system` | ClusterIP `postgresql:5432` (internal only) |
 | OpenClaw | Kustomize via ArgoCD | `openclaw` | `https://holdens-mac-mini.story-larch.ts.net:8447` |
+| Namespace Security | Kustomize via ArgoCD | `argocd` | cluster-wide Pod Security Standard labels |
+| Network Policies | Kustomize via ArgoCD | `argocd` | default-deny ingress/egress per namespace |
 
 ## Quick Start
 
@@ -267,6 +281,7 @@ kubectl get pods -A | grep -v Running | grep -v Completed
 | [k8s/apps/monitoring/README.md](k8s/apps/monitoring/README.md) | Grafana + Prometheus monitoring stack, ExternalSecret, SSO integration |
 | [k8s/apps/openclaw/README.md](k8s/apps/openclaw/README.md) | OpenClaw AI gateway deployment, configuration, image builds |
 | [k8s/apps/postgresql/README.md](k8s/apps/postgresql/README.md) | Database configuration, pg_hba.conf, PGDATA layout, password management |
+| [k8s/apps/trivy-operator/README.md](k8s/apps/trivy-operator/README.md) | Container image vulnerability scanning, ClientServer mode, Helm values |
 
 ## Documentation Freshness Tracking
 
@@ -288,5 +303,6 @@ When adding a new service or documentation file, add an entry to `.doc-manifest.
 
 1. **CI/CD Pipelines** -- Gitea Actions or Tekton for build and test automation
 2. **Agent Expansion** -- Develop and integrate more AI agents for homelab automation
-3. **Security Hardening** -- Network policies, RBAC, TLS everywhere, image scanning
-4. **Logging** -- Loki for centralized log aggregation
+3. **Logging** -- Loki for centralized log aggregation
+
+> **Completed in v1.1.0:** Security hardening — network policies (default-deny per namespace), Pod Security Standards enforcement, RBAC scope-down (OpenClaw cluster-admin removed), non-root execution for all services, and container image vulnerability scanning (Trivy Operator).

--- a/agents/workspaces/homelab-admin/AGENTS.md
+++ b/agents/workspaces/homelab-admin/AGENTS.md
@@ -214,7 +214,8 @@ Every PR that changes the project MUST include documentation updates. A PR witho
 | `skills/` or `agents/` or `k8s/apps/openclaw/` | `k8s/apps/openclaw/README.md`, `docs/ai-agents.md` |
 | Secrets pipeline (ExternalSecret, Infisical) | `docs/secret-management.md`, the consuming service's README |
 | Networking (Tailscale, services, ports) | `docs/networking.md`, the affected service's README |
-| New service added | Full checklist: service README, `docs/<service>.md` wrapper, `mkdocs.yml` nav, `docs/architecture.md` service map |
+| New service added | Full checklist: service README, `docs/<service>.md` wrapper, `mkdocs.yml` nav, `docs/architecture.md` service map, root `README.md` (architecture diagram, repo structure, deployed services, doc index) |
+| **Release milestone** | Review and update root `README.md` (see pre-release checklist in [Cutting a release](#cutting-a-release)) |
 
 ### Documentation conventions
 
@@ -227,8 +228,9 @@ Every PR that changes the project MUST include documentation updates. A PR witho
 Before creating a PR, ask yourself:
 1. Did I change any manifest, config, or code? → Update the service README.
 2. Did I add/remove/rename a service, port, secret, or endpoint? → Update `docs/architecture.md`, `docs/networking.md`, or `docs/secret-management.md` as applicable.
-3. Did I add a new service? → Create its README, create the `docs/` wrapper, add to `mkdocs.yml` nav, update `docs/architecture.md`.
-4. Can a reader of the docs still understand the current state of the system after my change? → If not, the docs are incomplete.
+3. Did I add a new service? → Create its README, create the `docs/` wrapper, add to `mkdocs.yml` nav, update `docs/architecture.md`, **update root `README.md`**.
+4. Am I cutting a release? → Run the pre-release checklist including full root `README.md` review.
+5. Can a reader of the docs still understand the current state of the system after my change? → If not, the docs are incomplete.
 
 ## Release Management
 
@@ -275,7 +277,13 @@ When all issues in a milestone are closed:
 
 2. **Determine version** from the highest-impact PR (check for `semver:breaking` first, then `type:feat`)
 
-3. **Create tag and GitHub Release:**
+3. **Pre-release checklist** — complete before tagging:
+   - All ArgoCD applications are `Synced` + `Healthy`
+   - Run `python scripts/doc-freshness.py` and resolve stale entries
+   - **Review root `README.md`** — the root README is the public face of the repo. Verify and update: architecture diagram (all namespaces/services), repository structure (new directories), deployed services table (new services/ports), documentation index (all doc files listed), Quick Start / secrets table, and Future Plans (move completed items)
+   - Run `python scripts/doc-freshness.py` again after updates to confirm all clear
+
+4. **Create tag and GitHub Release:**
    ```bash
    gh release create "v<MAJOR>.<MINOR>.<PATCH>" \
      --repo holdennguyen/homelab \
@@ -284,7 +292,7 @@ When all issues in a milestone are closed:
      --generate-notes --latest
    ```
 
-4. **Close milestone and create the next one:**
+5. **Close milestone and create the next one:**
    ```bash
    gh api repos/holdennguyen/homelab/milestones/<number> \
      --method PATCH -f state="closed"
@@ -292,7 +300,7 @@ When all issues in a milestone are closed:
      --method POST -f title="v<next-version>" -f description="<goal>"
    ```
 
-5. **Report** the release URL to the user
+6. **Report** the release URL to the user
 
 ### Milestone reassessment (after incidents)
 

--- a/skills/homelab-admin/SKILL.md
+++ b/skills/homelab-admin/SKILL.md
@@ -61,7 +61,7 @@ The Mac mini's Tailscale hostname is `holdens-mac-mini` on the tailnet `story-la
 | `external-secrets` | ESO operator, cert-controller, webhook |
 | `gitea-system` | Gitea, PostgreSQL (Gitea's DB) |
 | `infisical` | Infisical standalone, PostgreSQL, Redis, ingress-nginx |
-| `monitoring` | Prometheus, Grafana, Alertmanager, node-exporter, kube-state-metrics |
+| `monitoring` | Prometheus, Grafana, Alertmanager, node-exporter, kube-state-metrics, Trivy Operator, trivy-server |
 | `openclaw` | OpenClaw gateway (this pod) |
 
 ## ArgoCD applications
@@ -72,8 +72,14 @@ The Mac mini's Tailscale hostname is `holdens-mac-mini` on the tailnet `story-la
 | `external-secrets` | `secrets` | ESO Helm chart (installs CRDs) — sync wave 0 |
 | `external-secrets-config` | `secrets` | ClusterSecretStore for Infisical — sync wave 1 |
 | `infisical` | `secrets` | Infisical secret manager (managed by Terraform, not App of Apps) |
+| `authentik` | `apps` | Authentik SSO (Helm chart) |
+| `authentik-config` | `apps` | Authentik ExternalSecret and config |
 | `gitea` | `apps` | Gitea git forge |
 | `monitoring` | `apps` | kube-prometheus-stack (Prometheus + Grafana + Alertmanager) |
+| `monitoring-config` | `apps` | Monitoring ExternalSecret and config |
+| `trivy-operator` | `apps` | Container image vulnerability scanning (ClientServer mode) |
+| `namespace-security` | `apps` | Pod Security Standard labels per namespace |
+| `networking-policies` | `apps` | Default-deny NetworkPolicy per namespace |
 | `openclaw` | `apps` | OpenClaw AI gateway (this service) |
 | `postgresql` | `data` | PostgreSQL for Gitea |
 
@@ -83,7 +89,7 @@ The Mac mini's Tailscale hostname is `holdens-mac-mini` on the tailnet `story-la
 |---|---|---|
 | `secrets` | Secret management infra (ESO, Infisical) | `external-secrets`, `infisical` |
 | `data` | Databases and persistent stores | `gitea-system` |
-| `apps` | User-facing applications | `gitea-system`, `kubernetes-dashboard`, `openclaw` |
+| `apps` | User-facing applications | `gitea-system`, `authentik`, `monitoring`, `openclaw`, `argocd` (for cluster-wide policies) |
 
 ## Persistent volumes
 
@@ -94,6 +100,7 @@ The Mac mini's Tailscale hostname is `holdens-mac-mini` on the tailnet `story-la
 | `data-postgresql-0` | `infisical` | 8Gi | Infisical's PostgreSQL data |
 | `redis-data-redis-master-0` | `infisical` | 8Gi | Infisical's Redis data |
 | `openclaw-data` | `openclaw` | 5Gi | OpenClaw state, workspaces, sessions |
+| `data-trivy-server-0` | `monitoring` | 5Gi | Trivy vulnerability DB cache (ClientServer mode) |
 
 ## ExternalSecrets
 
@@ -188,7 +195,8 @@ The repo structure:
 3. Add to `k8s/apps/argocd/kustomization.yaml`
 4. If the service needs secrets: add to Infisical, create ExternalSecret, reference in deployment
 5. If the service needs a Tailscale endpoint: `tailscale serve --bg --https <port> http://localhost:<nodeport>`
-6. Push to `main`
+6. Update root `README.md` — architecture diagram, repository structure, deployed services table, documentation index
+7. Push to `main`
 
 ## Adding secrets for a service
 


### PR DESCRIPTION
## Summary

Establishes a sustainable strategy for keeping the root `README.md` up-to-date without the false-positive noise that caused us to remove it from doc-freshness tracking.

**Three-pronged approach:**

1. **Update now** — the README was missing trivy-operator, namespace-security, networking-policies, and had stale Future Plans
2. **Narrow tracking in `.doc-manifest.yml`** — map README to only `k8s/apps/argocd/kustomization.yaml` and `mkdocs.yml` (structural indicator files that change when services or docs are added)
3. **Release gate** — explicit "Review root README" step in the release checklist (`.cursor/rules/homelab.mdc` and `agents/workspaces/homelab-admin/AGENTS.md`)

### Files changed

| File | What |
|------|------|
| `README.md` | Add missing services to diagram, repo structure, services table, doc index; update Future Plans |
| `.doc-manifest.yml` | Re-add README.md with narrow sources |
| `.cursor/rules/homelab.mdc` | Add release checklist, update "What to update" table and "Adding a new service" checklist |
| `agents/workspaces/homelab-admin/AGENTS.md` | Add pre-release checklist step, update doc review matrix and verification step |
| `skills/homelab-admin/SKILL.md` | Update applications/namespaces/PVCs tables, add README to "Adding a new service" |

## Test plan

- [ ] `python scripts/doc-freshness.py` shows README.md as tracked and up-to-date after merge
- [ ] No false positives on unrelated code changes (narrow sources only trigger on structural files)


Made with [Cursor](https://cursor.com)