### PR TITLE
docs: pre-release doc freshness sweep for v1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ terraform/terraform.tfvars
 terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
 terraform/*.tfplan
+terraform/tfplan
 terraform/.argocd-root-app.yaml
 terraform/.infisical-app.yaml
 

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -292,7 +292,7 @@ Key gateway-level settings in `openclaw.json`:
 | `tools.sessions.visibility` | `"all"` | Orchestrator can view sub-agent session history |
 | `tools.agentToAgent.enabled` | `true` | Enables cross-agent communication |
 
-The container image (`Dockerfile.openclaw`) includes ops tools (kubectl, helm, terraform, argocd, jq, git, gh) and the pod runs with a `cluster-admin` ServiceAccount, so agents can execute cluster operations directly.
+The container image (`Dockerfile.openclaw`) includes ops tools (kubectl, helm, terraform, argocd, jq, git, gh). The pod's ServiceAccount has a namespace-scoped Role in `openclaw` with read-only access to pods, logs, secrets, configmaps, services, PVCs, and exec into pods — it does NOT have cluster-wide access (the previous `cluster-admin` binding was removed in v1.1.0).
 
 ### Per-Agent Skill Assignment
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,7 +206,7 @@ flowchart TD
     subgraph monNs["monitoring namespace"]
         GrafanaPod["Grafana\nNodePort :30090"]
         PromPod["Prometheus\n15d retention"]
-        TrivyPod["Trivy Operator\n(vuln scanning)"]
+        TrivyPod["Trivy Operator\n(ClientServer mode)"]
         GrafanaPod --> PromPod
     end
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -23,7 +23,7 @@ kubectl cluster-info              # should show the API server URL
 
 ## Architecture Summary
 
-The bootstrap runs in strict order. Each step depends on the previous:
+The bootstrap runs in strict order. Each step depends on the previous. Security enforcement (non-root execution, Pod Security Standards, network policies) is applied automatically by ArgoCD after the bootstrap completes — no additional manual steps are required.
 
 ```mermaid
 flowchart TD

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -465,8 +465,13 @@ Owned by `homelab-admin` or the user — sub-agents never create tags or release
 1. Verify all issues in the milestone are closed
 2. Check for `status:reverted` PRs (merge + revert = net zero, exclude from changelog)
 3. Determine the version from the highest-impact non-reverted PR
-4. Create a git tag and GitHub Release: `gh release create "v<version>" --target main --generate-notes --latest`
-5. Close the milestone and create the next one
+4. **Pre-release checklist:**
+    - All ArgoCD applications are `Synced` + `Healthy`
+    - Run `python scripts/doc-freshness.py` and resolve stale entries
+    - **Review root `README.md`** — architecture diagram, repository structure, deployed services table, documentation index, Quick Start, and Future Plans must reflect the current state
+    - Run doc freshness again after any updates
+5. Create a git tag and GitHub Release: `gh release create "v<version>" --target main --generate-notes --latest`
+6. Close the milestone and create the next one
 
 ### Milestone reassessment
 

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -8,6 +8,7 @@ This document covers how secrets are managed in the homelab: where they are stor
 2. **Infisical is the single source of truth** — all application credentials live in one place with an audit trail.
 3. **Terraform owns bootstrap secrets** — a small set of credentials that Infisical itself needs to start (ENCRYPTION_KEY, AUTH_SECRET, postgres/redis passwords) are injected by Terraform from a local `terraform.tfvars` file that is gitignored.
 4. **ESO bridges Infisical to Kubernetes** — the External Secrets Operator watches `ExternalSecret` resources and creates real `Secret` objects in the cluster, polling Infisical every hour.
+5. **Least privilege** — both ESO and Infisical run with non-root security contexts and read-only root filesystems where supported by their upstream charts. See each service's `README.md` for security details.
 
 ## Secret Layers
 

--- a/k8s/apps/argocd/README.md
+++ b/k8s/apps/argocd/README.md
@@ -58,7 +58,7 @@ flowchart TD
 | `applications/authentik-app.yaml` | Authentik SSO Helm chart |
 | `applications/authentik-config-app.yaml` | Authentik ExternalSecret (authentik namespace) |
 | `applications/openclaw-app.yaml` | OpenClaw AI gateway deployment |
-| `applications/trivy-operator-app.yaml` | Trivy vulnerability scanner Helm chart (monitoring namespace) |
+| `applications/trivy-operator-app.yaml` | Trivy vulnerability scanner Helm chart (monitoring namespace, ClientServer mode) |
 | `applications/namespace-security-app.yaml` | Pod Security Standard labels for namespaces |
 | `applications/networking-policies-app.yaml` | Default-deny NetworkPolicies across all namespaces |
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 # Terraform — Bootstrap Layer
 
-This directory contains the Terraform configuration that bootstraps the homelab cluster. It runs **once** to install ArgoCD and create all initial Kubernetes Secrets. After that, ArgoCD takes over GitOps management.
+This directory contains the Terraform configuration that bootstraps the homelab cluster. It runs **once** to install ArgoCD and create all initial Kubernetes Secrets. After that, ArgoCD takes over GitOps management — including security enforcement (non-root execution, Pod Security Standards, network policies), which is managed per-service in `k8s/apps/` rather than at the Terraform bootstrap layer.
 
 ## What Terraform Manages
 


### PR DESCRIPTION
## Summary
- Fix 7 stale documentation entries before v1.1.0 release
- Correct OpenClaw RBAC description (cluster-admin was removed in security hardening)
- Add pre-release checklist to release process in git-workflow.md
- Minor accuracy updates across architecture, bootstrap, secret management, and argocd docs
- Add `terraform/tfplan` to `.gitignore`

## Doc freshness status
17/17 up-to-date after this PR.

## Test plan
- [x] `python scripts/doc-freshness.py` reports 0 stale
- [ ] Content reviewed for accuracy

Made with [Cursor](https://cursor.com)