### PR TITLE
fix: prevent agents from creating duplicate GitHub issues

### DIFF
--- a/agents/workspaces/devops-sre/AGENTS.md
+++ b/agents/workspaces/devops-sre/AGENTS.md
@@ -42,7 +42,36 @@ git config user.email "devops-sre@openclaw.homelab"
 
 ### For every change
 
-1. **Create a labeled GitHub issue** assigned to the current milestone:
+1. **Obtain a GitHub issue** — every change is tracked by exactly one issue. **Never create a duplicate.**
+
+   **If you received an existing issue** (assigned by orchestrator, user, or referenced in the task):
+
+   ```bash
+   # Read the issue
+   gh issue view <issue-number> --repo holdennguyen/homelab
+
+   # Add your labels (--add-label won't duplicate existing ones)
+   gh issue edit <issue-number> \
+     --add-label "agent:devops-sre,type:<type>,area:<area>,priority:<priority>" \
+     --repo holdennguyen/homelab
+
+   # Assign milestone if not already set
+   gh issue edit <issue-number> \
+     --milestone "<current-milestone>" \
+     --repo holdennguyen/homelab
+
+   # Comment that you're picking it up
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   Picking up this issue.
+
+   ---
+   Agent: devops-sre | OpenClaw Homelab
+   EOF
+   )"
+   ```
+
+   **If no existing issue (self-initiated work)** — create one:
+
    ```bash
    gh issue create \
      --title "<type>: <description>" \
@@ -58,7 +87,10 @@ git config user.email "devops-sre@openclaw.homelab"
      --milestone "<current-milestone>" \
      --repo holdennguyen/homelab
    ```
+
    If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
+
+   **How to decide:** If the orchestrator or user mentions an issue number (e.g., "fix #42", "address issue 42") or you were spawned with a task referencing an existing issue, adopt it. Only create a new issue when you discovered the problem yourself and no issue exists yet.
 
 2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
    ```bash

--- a/agents/workspaces/homelab-admin/AGENTS.md
+++ b/agents/workspaces/homelab-admin/AGENTS.md
@@ -31,9 +31,10 @@ When a task requires deep expertise, spawn a sub-agent:
 Use `sessions_spawn` to delegate. Always include in the task context:
 1. The task description and expected outcome
 2. Any relevant file paths or service names
-3. The agent label to use on the issue (e.g. `agent:devops-sre`)
-4. The type, area, and priority labels to use
-5. The current milestone name to assign to the issue and PR
+3. **The existing GitHub issue number** if one exists (e.g., "Address issue #42") — this prevents the sub-agent from creating a duplicate issue
+4. The agent label to use on the issue (e.g. `agent:devops-sre`)
+5. The type, area, and priority labels to use
+6. The current milestone name to assign to the issue and PR
 
 ### Delegation flow
 
@@ -64,7 +65,36 @@ git config user.email "homelab-admin@openclaw.homelab"
 
 ### For every change
 
-1. **Create a labeled GitHub issue** assigned to the current milestone:
+1. **Obtain a GitHub issue** — every change is tracked by exactly one issue. **Never create a duplicate.**
+
+   **If you received an existing issue** (assigned by user, or referenced in the task):
+
+   ```bash
+   # Read the issue
+   gh issue view <issue-number> --repo holdennguyen/homelab
+
+   # Add your labels (--add-label won't duplicate existing ones)
+   gh issue edit <issue-number> \
+     --add-label "agent:homelab-admin,type:<type>,area:<area>,priority:<priority>" \
+     --repo holdennguyen/homelab
+
+   # Assign milestone if not already set
+   gh issue edit <issue-number> \
+     --milestone "<current-milestone>" \
+     --repo holdennguyen/homelab
+
+   # Comment that you're picking it up
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   Picking up this issue.
+
+   ---
+   Agent: homelab-admin | OpenClaw Homelab
+   EOF
+   )"
+   ```
+
+   **If no existing issue (self-initiated work)** — create one:
+
    ```bash
    gh issue create \
      --title "<type>: <description>" \
@@ -80,7 +110,10 @@ git config user.email "homelab-admin@openclaw.homelab"
      --milestone "<current-milestone>" \
      --repo holdennguyen/homelab
    ```
+
    If no open milestone exists, create one (see [Release Management](#release-management)).
+
+   **How to decide:** If the user mentions an issue number (e.g., "fix #42", "address issue 42") or you were given an existing issue, adopt it. Only create a new issue when you discovered the problem yourself and no issue exists yet.
 
 2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
    ```bash

--- a/agents/workspaces/qa-tester/AGENTS.md
+++ b/agents/workspaces/qa-tester/AGENTS.md
@@ -108,7 +108,36 @@ git config user.email "qa-tester@openclaw.homelab"
 
 ### For every change
 
-1. **Create a labeled GitHub issue** assigned to the current milestone:
+1. **Obtain a GitHub issue** — every change is tracked by exactly one issue. **Never create a duplicate.**
+
+   **If you received an existing issue** (assigned by orchestrator, user, or referenced in the task):
+
+   ```bash
+   # Read the issue
+   gh issue view <issue-number> --repo holdennguyen/homelab
+
+   # Add your labels (--add-label won't duplicate existing ones)
+   gh issue edit <issue-number> \
+     --add-label "agent:qa-tester,type:<type>,area:<area>,priority:<priority>" \
+     --repo holdennguyen/homelab
+
+   # Assign milestone if not already set
+   gh issue edit <issue-number> \
+     --milestone "<current-milestone>" \
+     --repo holdennguyen/homelab
+
+   # Comment that you're picking it up
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   Picking up this issue.
+
+   ---
+   Agent: qa-tester | OpenClaw Homelab
+   EOF
+   )"
+   ```
+
+   **If no existing issue (self-initiated work)** — create one:
+
    ```bash
    gh issue create \
      --title "<type>: <description>" \
@@ -124,7 +153,10 @@ git config user.email "qa-tester@openclaw.homelab"
      --milestone "<current-milestone>" \
      --repo holdennguyen/homelab
    ```
+
    If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
+
+   **How to decide:** If the orchestrator or user mentions an issue number (e.g., "fix #42", "address issue 42") or you were spawned with a task referencing an existing issue, adopt it. Only create a new issue when you discovered the problem yourself and no issue exists yet.
 
 2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
    ```bash

--- a/agents/workspaces/security-analyst/AGENTS.md
+++ b/agents/workspaces/security-analyst/AGENTS.md
@@ -42,7 +42,36 @@ git config user.email "security-analyst@openclaw.homelab"
 
 ### For every change
 
-1. **Create a labeled GitHub issue** assigned to the current milestone:
+1. **Obtain a GitHub issue** — every change is tracked by exactly one issue. **Never create a duplicate.**
+
+   **If you received an existing issue** (assigned by orchestrator, user, or referenced in the task):
+
+   ```bash
+   # Read the issue
+   gh issue view <issue-number> --repo holdennguyen/homelab
+
+   # Add your labels (--add-label won't duplicate existing ones)
+   gh issue edit <issue-number> \
+     --add-label "agent:security-analyst,type:<type>,area:<area>,priority:<priority>" \
+     --repo holdennguyen/homelab
+
+   # Assign milestone if not already set
+   gh issue edit <issue-number> \
+     --milestone "<current-milestone>" \
+     --repo holdennguyen/homelab
+
+   # Comment that you're picking it up
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   Picking up this issue.
+
+   ---
+   Agent: security-analyst | OpenClaw Homelab
+   EOF
+   )"
+   ```
+
+   **If no existing issue (self-initiated work)** — create one:
+
    ```bash
    gh issue create \
      --title "<type>: <description>" \
@@ -58,7 +87,10 @@ git config user.email "security-analyst@openclaw.homelab"
      --milestone "<current-milestone>" \
      --repo holdennguyen/homelab
    ```
+
    If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
+
+   **How to decide:** If the orchestrator or user mentions an issue number (e.g., "fix #42", "address issue 42") or you were spawned with a task referencing an existing issue, adopt it. Only create a new issue when you discovered the problem yourself and no issue exists yet.
 
 2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
    ```bash

--- a/agents/workspaces/software-engineer/AGENTS.md
+++ b/agents/workspaces/software-engineer/AGENTS.md
@@ -33,7 +33,36 @@ git config user.email "software-engineer@openclaw.homelab"
 
 ### For every change
 
-1. **Create a labeled GitHub issue** assigned to the current milestone:
+1. **Obtain a GitHub issue** — every change is tracked by exactly one issue. **Never create a duplicate.**
+
+   **If you received an existing issue** (assigned by orchestrator, user, or referenced in the task):
+
+   ```bash
+   # Read the issue
+   gh issue view <issue-number> --repo holdennguyen/homelab
+
+   # Add your labels (--add-label won't duplicate existing ones)
+   gh issue edit <issue-number> \
+     --add-label "agent:software-engineer,type:<type>,area:<area>,priority:<priority>" \
+     --repo holdennguyen/homelab
+
+   # Assign milestone if not already set
+   gh issue edit <issue-number> \
+     --milestone "<current-milestone>" \
+     --repo holdennguyen/homelab
+
+   # Comment that you're picking it up
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   Picking up this issue.
+
+   ---
+   Agent: software-engineer | OpenClaw Homelab
+   EOF
+   )"
+   ```
+
+   **If no existing issue (self-initiated work)** — create one:
+
    ```bash
    gh issue create \
      --title "<type>: <description>" \
@@ -49,7 +78,10 @@ git config user.email "software-engineer@openclaw.homelab"
      --milestone "<current-milestone>" \
      --repo holdennguyen/homelab
    ```
+
    If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
+
+   **How to decide:** If the orchestrator or user mentions an issue number (e.g., "fix #42", "address issue 42") or you were spawned with a task referencing an existing issue, adopt it. Only create a new issue when you discovered the problem yourself and no issue exists yet.
 
 2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan:
    ```bash

--- a/skills/gitops/SKILL.md
+++ b/skills/gitops/SKILL.md
@@ -144,7 +144,40 @@ Example: `devops-sre/feat/42-redis-caching`
 
 ### Step-by-step process
 
-1. **Create a GitHub issue** (or receive an existing one) — every change starts with a labeled issue assigned to the current milestone:
+1. **Obtain a GitHub issue** — every change is tracked by exactly one issue. **Never create a duplicate.**
+
+   **Scenario A — You received an existing issue** (assigned by user, orchestrator, or referenced in the task):
+
+   Read the issue, adopt it by adding your labels, and comment that you're picking it up:
+
+   ```bash
+   # Read the issue to understand requirements
+   gh issue view <issue-number> --repo holdennguyen/homelab
+
+   # Add your agent label and any missing labels (--add-label won't duplicate existing ones)
+   gh issue edit <issue-number> \
+     --add-label "agent:<your-agent-id>,type:<type>,area:<area>,priority:<priority>" \
+     --repo holdennguyen/homelab
+
+   # Assign to the current milestone if not already assigned
+   gh issue edit <issue-number> \
+     --milestone "<current-milestone>" \
+     --repo holdennguyen/homelab
+
+   # Comment that you're picking it up
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   Picking up this issue.
+
+   ---
+   Agent: <your-agent-id> | OpenClaw Homelab
+   EOF
+   )"
+   ```
+
+   **Scenario B — No existing issue (self-initiated work):**
+
+   Create a new issue:
+
    ```bash
    gh issue create \
      --title "<type>: <description>" \
@@ -160,7 +193,10 @@ Example: `devops-sre/feat/42-redis-caching`
      --milestone "<current-milestone>" \
      --repo holdennguyen/homelab
    ```
+
    Capture the issue number from the output. If no open milestone exists, ask the orchestrator (or user) to create one before proceeding.
+
+   **How to decide:** If the user or orchestrator mentions an issue number (e.g., "fix #42", "address issue 42"), or if you were spawned with a task that references an existing issue, use Scenario A. Only use Scenario B when you discovered the problem yourself and no issue exists yet.
 
 2. **Plan the implementation and comment it on the issue** — before writing any code, post your plan as a comment:
    ```bash
@@ -343,6 +379,7 @@ git push origin main
 - Never bundle unrelated changes in one PR
 - Never use `kubectl apply` for persistent resources (ArgoCD will revert them)
 - Never create an issue or PR without labels
+- **Never create a new issue when an existing one was provided** — adopt it with `gh issue edit` and `gh issue comment` instead
 - Never commit without the `[<agent-id>]` suffix in the message
 - Never create an issue or PR body without the agent signature footer
 - Never use a branch name without the `<agent-id>/` prefix


### PR DESCRIPTION
## Summary
- Replaced step 1 ("Create a GitHub issue") in the git workflow with a two-scenario decision flow across all 6 agent/skill files
- **Scenario A (existing issue):** Agent reads the issue, adds its labels via `gh issue edit --add-label`, assigns milestone, and comments — no new issue created
- **Scenario B (self-initiated):** Agent creates a new issue as before, only when it discovered the problem itself
- Added "How to decide" guidance so agents can distinguish the two scenarios
- Added explicit "never create a duplicate" rule to the "What NOT to do" list in gitops skill
- Updated homelab-admin delegation context to pass existing issue numbers to sub-agents

## Test plan
- [ ] Verify OpenClaw agent adopts existing issues instead of creating duplicates
- [ ] Verify self-initiated workflow still creates new issues correctly

Made with [Cursor](https://cursor.com)