### PR TITLE
feat: add Cursor skills, subagents, and commands; slim down homelab.mdc

### DIFF
--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -1,0 +1,43 @@
+---
+name: verifier
+description: Post-deploy health verification for the homelab cluster. Use after merging PRs that modify cluster resources to verify ArgoCD sync and service health.
+model: fast
+is_background: true
+---
+
+You are a deployment verifier for a GitOps-managed Kubernetes homelab. Your job is to confirm that a merge to `main` resulted in a healthy cluster state.
+
+Run these checks in order and report results:
+
+1. **ArgoCD sync status** — all applications should be `Synced` + `Healthy`:
+   ```bash
+   kubectl get applications -n argocd
+   ```
+
+2. **Pod health** — no pods in error states:
+   ```bash
+   kubectl get pods -A | grep -v Running | grep -v Completed
+   ```
+
+3. **ExternalSecrets** — all secrets synced:
+   ```bash
+   kubectl get externalsecret -A
+   ```
+
+4. **Recent events** — no error events in last 5 minutes:
+   ```bash
+   kubectl get events -A --sort-by='.lastTimestamp' --field-selector type!=Normal | tail -10
+   ```
+
+5. **Service endpoints** — key services reachable:
+   ```bash
+   curl -sf http://localhost:30300/api/v1/version   # Gitea
+   curl -sf http://localhost:30789/health            # OpenClaw
+   ```
+
+Report findings as:
+- **PASS** — all checks green, deployment successful
+- **WARN** — minor issues (high restart counts, non-critical pod not ready) that don't require rollback
+- **FAIL** — service degradation detected, recommend invoking `/incident-response`
+
+For each failing check, include the command output and a specific diagnosis.

--- a/.cursor/commands/address-issue.md
+++ b/.cursor/commands/address-issue.md
@@ -1,0 +1,44 @@
+Read the specified GitHub issue, draft an implementation plan, and execute the full workflow.
+
+## Steps
+
+1. **Read the issue** to understand requirements:
+   ```bash
+   gh issue view <issue-number> --repo holdennguyen/homelab
+   ```
+
+2. **Draft an implementation plan** covering:
+   - Which files/services will be modified
+   - The approach and key design decisions
+   - Risks, dependencies, or open questions
+   - Docs that need updating (check the `/documentation` skill for the matrix)
+
+3. **Comment the plan on the issue**:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "## Implementation Plan ..."
+   ```
+
+4. **Create a feature branch** from latest main:
+   ```bash
+   git checkout main && git pull origin main
+   git checkout -b <type>/<short-description>
+   ```
+
+5. **Implement the changes** referencing the plan. Include documentation updates in the same PR.
+
+6. **Before pushing**, sync with main:
+   ```bash
+   git fetch origin main && git merge origin/main --no-edit
+   ```
+
+7. **Commit, push, and create a PR**:
+   ```bash
+   git add <files>
+   git commit -m "<type>: <description>"
+   git push -u origin HEAD
+   gh pr create --title "<type>: <description>" --body "Closes #<issue-number> ..."
+   ```
+
+8. **Report** the PR URL when done.
+
+If the issue number is not provided, ask the user for it before proceeding.

--- a/.cursor/commands/pre-merge-check.md
+++ b/.cursor/commands/pre-merge-check.md
@@ -1,0 +1,54 @@
+Run pre-merge validation checks on the current branch before merging a PR that modifies cluster resources.
+
+## Checks to Run
+
+### 1. YAML Validation
+
+For each modified YAML file under `k8s/`:
+```bash
+kubectl apply --dry-run=client -f <file>
+```
+Or for full kustomize builds:
+```bash
+kustomize build k8s/apps/<service>/ | kubectl apply --dry-run=client -f -
+```
+
+### 2. Helm Value Verification
+
+If any ArgoCD Application CR `valuesObject` was modified, verify every changed key exists in the chart:
+```bash
+helm show values <repo>/<chart> --version <version> | grep -A5 "<key>"
+```
+Flag as **FAIL** if any key is not found — Helm silently ignores unknown keys.
+
+### 3. Secret Scan
+
+Check the diff for accidentally committed secrets:
+```bash
+git diff origin/main...HEAD
+```
+Flag any strings that look like API keys, passwords, tokens, or base64-encoded credentials.
+
+### 4. Doc Freshness
+
+Check if documentation needs updating for the files changed in this branch:
+```bash
+python scripts/doc-freshness.py --check-pr
+```
+Flag as **WARN** if the script reports missing doc updates.
+
+### 5. Label and Convention Check
+
+For modified K8s manifests, verify:
+- All resources have `app.kubernetes.io/*` labels (name, instance, part-of, managed-by)
+- Namespaces exist or `CreateNamespace=true` is set
+- Container images use pinned tags (not `:latest` for upstream)
+
+## Report Format
+
+Summarize results as a checklist:
+- [ ] YAML validation — PASS/FAIL
+- [ ] Helm value keys — PASS/FAIL/N/A
+- [ ] Secret scan — PASS/FAIL
+- [ ] Doc freshness — PASS/WARN
+- [ ] Labels and conventions — PASS/FAIL

--- a/.cursor/rules/homelab.mdc
+++ b/.cursor/rules/homelab.mdc
@@ -16,209 +16,38 @@ This is a GitOps-driven homelab running on a Mac mini M4 with OrbStack Kubernete
 ## Core Rules
 
 - All persistent cluster changes go through git → ArgoCD sync. Never use `kubectl apply` for long-lived resources.
-- Never commit secrets, API keys, or credentials to git. Use the Infisical → ESO pipeline (see `skills/secret-management/SKILL.md`).
+- Never commit secrets, API keys, or credentials to git. Use the Infisical → ESO pipeline (`/secret-management` skill).
 - ArgoCD Application CRs must follow the project and label conventions in `k8s/apps/argocd/README.md` (projects: `secrets`, `data`, `apps`; labels: `app.kubernetes.io/{name,part-of,component,managed-by}`).
 - Prefer Kustomize over Helm for app workloads. Helm is only used for upstream charts (ESO, Infisical).
 - Before modifying Helm `valuesObject`, always verify keys with `helm show values` — charts silently ignore unknown keys. See `kubernetes.mdc` for the full rule.
-- After merging changes to `main`, verify ArgoCD sync and pod health before considering the task complete. If services degrade, follow the rollback procedures in `skills/incident-response/SKILL.md`.
-- Documentation lives in `docs/` and is served by MkDocs. See the Documentation Rule below.
+- After merging changes to `main`, verify ArgoCD sync and pod health before considering the task complete. If services degrade, use the `/incident-response` skill.
+- Documentation lives in `docs/` and is served by MkDocs. Use the `/documentation` skill for the update matrix and conventions.
 
-## Mandatory Git Workflow (Cursor)
+## Git Workflow
 
-The `main` branch is **protected**. Never push directly to `main` — all changes require a feature branch and a pull request. This applies to Cursor just as it applies to OpenClaw agents.
-
-### Issue-First Planning (mandatory)
-
-When addressing a GitHub issue (whether assigned by a user, picked from the backlog, or self-created), **always plan before coding**:
-
-1. **Read the issue** — understand the requirements, acceptance criteria, and linked context
-2. **Draft an implementation plan** covering:
-   - Which files/services will be modified
-   - The approach and key design decisions
-   - Risks, dependencies, or open questions
-   - Docs that need updating (check the documentation matrix below)
-3. **Comment the plan on the issue** using `gh issue comment`:
-   ```bash
-   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
-   ## Implementation Plan
-
-   **Approach:** <high-level summary>
-
-   **Files to change:**
-   - `<path>` — <what and why>
-
-   **Risks / open questions:**
-   - <any concerns>
-
-   **Docs to update:**
-   - <list from documentation matrix>
-   EOF
-   )"
-   ```
-4. **Wait for feedback** if the plan is non-trivial or the issue was filed by someone else — proceed immediately only for straightforward changes you filed yourself
-5. **Reference the plan** throughout implementation — commit messages and PR body should trace back to the plan
-
-This ensures every change is deliberate, reviewable, and traceable. Jumping straight to code without a plan leads to missed requirements and wasted review cycles.
-
-### Branch workflow
-
-1. **Start from latest main:**
- ```bash
- git checkout main && git pull origin main
- git checkout -b <type>/<short-description>
- ```
- Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `security/`
-
-2. **Make changes** (referencing the plan from the issue) and commit with conventional messages:
-   ```bash
-   git add <files>
-   git commit -m "<type>: <description>"
-   ```
-   Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `security`
-
-3. **Keep your branch up to date** — before every push:
-   ```bash
-   git fetch origin main
-   git merge origin/main --no-edit
-   ```
-
-4. **Push and create a PR:**
-   ```bash
-   git push -u origin HEAD
-   gh pr create --title "<type>: <description>" --body "<summary>"
-   ```
-
-### Post-merge cleanup
-
-**Never delete a branch until the merge is confirmed.** Always verify before cleanup:
-
-```bash
-gh pr view <number> --json state,mergedAt --jq '"state: \(.state), merged: \(.mergedAt // "NOT MERGED")"'
-```
-
-Only proceed with deletion if the output shows `state: MERGED` and a merge timestamp. If the PR was closed without merging, do NOT delete the branch — the commits are only on that branch.
-
-```bash
-# Only after confirming MERGED:
-git checkout main && git pull origin main
-git branch -d <branch-name>
-git push origin --delete <branch-name>
-```
-
-### Rules
-
-- **Never push to `main` directly** — branch protection will reject it
-- **Never force-push to `main`** — this is destructive and irreversible
-- **Never delete a branch without verifying the PR was merged** — use `gh pr view` to confirm
-- One PR per logical change — don't bundle unrelated changes
-- Include documentation updates in the same PR as the implementation
-- Never commit secrets, API keys, or credentials
-- After merge, verify ArgoCD sync and pod health (for K8s changes)
-- If a merge causes service degradation, follow rollback procedures in `skills/incident-response/SKILL.md`
-
-### Pre-merge validation (for K8s/Helm changes)
-
-Before merging PRs that modify cluster resources:
-- Verify Helm value keys exist: `helm show values <chart>` (see `kubernetes.mdc`)
-- Validate YAML: `kubectl apply --dry-run=client -f <file>`
-- Check container image compatibility with `securityContext` changes
-- Review ArgoCD sync wave dependencies
-
-### Release checklist
-
-Before tagging a new release (e.g. `v1.1.0`), complete every item:
-
-1. **All milestone PRs merged** — no open PRs targeting this release
-2. **ArgoCD health** — all applications `Synced` + `Healthy` (`kubectl get applications -n argocd`)
-3. **Doc freshness** — run `python scripts/doc-freshness.py` and resolve any stale entries
-4. **Root README review** — the root `README.md` is the public face of the repo. It is tracked in `.doc-manifest.yml` with narrow sources (kustomization.yaml, mkdocs.yml), but those triggers only catch structural additions. Manually review and update:
-   - Architecture diagram — does it reflect all current namespaces and services?
-   - Repository structure — any new top-level directories or service directories?
-   - Deployed services table — any new services, changed ports, or removed services?
-   - Documentation index — does the table list every doc file?
-   - Quick Start / secrets table — any new secrets or changed bootstrap steps?
-   - Future Plans — move completed items out, add new plans
-5. **Tag and release** — `git tag -a vX.Y.Z -m "release description" && git push origin vX.Y.Z`
-
-## Documentation Rule (mandatory)
-
-After every implementation, update the related documentation before considering the task complete. This is not optional.
-
-### Doc freshness tracking
-
-The repo uses `.doc-manifest.yml` to map every documentation file to its implementation sources. Before creating a PR, run:
-
-```bash
-python scripts/doc-freshness.py --check-pr    # which docs this branch should update
-python scripts/doc-freshness.py --stale       # full staleness report
-```
-
-The `doc-freshness` GitHub Actions workflow runs on every PR and will comment if mapped docs are missing updates. The manifest is the **source of truth** for doc-to-source relationships — when adding a new service or doc, add an entry to `.doc-manifest.yml`.
-
-### Single source of truth: `k8s/apps/<service>/README.md`
-
-Every service directory under `k8s/apps/` **must** have a `README.md`. This README is the **single source of truth** for that service's documentation. The corresponding `docs/<service>.md` is always a thin MkDocs wrapper that includes the README:
-
-```markdown
----
-title: <Service Name>
----
-
-{%
-   include-markdown "../k8s/apps/<service>/README.md"
-%}
-```
-
-**Never write documentation directly in `docs/<service>.md`** for services that have a `k8s/apps/<service>/` directory. Always edit the README instead.
-
-### README structure
-
-Every `k8s/apps/<service>/README.md` should include these sections (adapt as needed):
-
-1. **Title + one-line description** — what the service does
-2. **Architecture** — mermaid diagram showing the service's components and connections
-3. **Directory Contents** — table listing every file in the directory and its purpose
-4. **Configuration** — key settings, Helm values, or Kustomize details
-5. **Secrets in Infisical** — table of secret keys the service consumes (if any)
-6. **Networking** — table with container port, NodePort, Tailscale port, and access URL
-7. **Operational Commands** — common kubectl commands for the service
-8. **Troubleshooting** — table of symptom / cause / fix
-
-### What to update
-
-| Change area | Docs to update |
-|---|---|
-| `k8s/apps/<service>/` manifests | `k8s/apps/<service>/README.md` (the single source of truth) |
-| `k8s/apps/argocd/` (projects, applications) | `k8s/apps/argocd/README.md`, `docs/architecture.md` (Layer 1 diagram / service map) |
-| `terraform/` | `docs/bootstrap.md`, `docs/architecture.md` (Layer 0 section) |
-| `skills/` or `agents/` or `k8s/apps/openclaw/` | `k8s/apps/openclaw/README.md`, `docs/ai-agents.md` |
-| Secrets pipeline (ExternalSecret, Infisical) | `docs/secret-management.md` |
-| Networking (Tailscale, services, ports) | `docs/networking.md` |
-| New service added | See "Adding a new service" checklist below |
-| **Release milestone** | Review and update root `README.md` (see release checklist above) |
-
-### Adding a new service (documentation checklist)
-
-1. Create `k8s/apps/<service>/README.md` following the README structure above
-2. Create `docs/<service>.md` as a thin `include-markdown` wrapper (see template above)
-3. Add `<service>.md` to the `nav` in `mkdocs.yml`
-4. Add doc → source mapping to `.doc-manifest.yml`
-5. Update the service map and repository layout in `docs/architecture.md`
-6. Update root `README.md` — architecture diagram, repository structure, deployed services table, and documentation index
-7. If the service has secrets, update `docs/secret-management.md` and `k8s/apps/infisical/README.md` inventory
-8. If the service has a Tailscale endpoint, update `docs/networking.md` and `docs/bootstrap.md` (Tailscale Serve commands)
-
-### Rules
-
-- Keep docs concise — document the *what* and *why*, not step-by-step kubectl commands.
-- Never remove documentation for existing services without explicit instruction.
-- **Always include doc changes in the same commit as the implementation** (or as a follow-up commit in the same push). Pushing to `main` triggers the GitHub Pages deploy workflow (`.github/workflows/docs.yml`), so docs go live automatically — but only if they are committed and pushed.
+The `main` branch is **protected**. Never push directly to `main` — all changes require a feature branch and a pull request. Use the `/git-workflow` skill for the full branch workflow, PR creation, and post-merge cleanup procedures. Use `/address-issue` to execute the full issue-to-PR workflow.
 
 ## Key Paths
 
 - `terraform/` — Layer 0 bootstrap (ArgoCD, credentials)
 - `k8s/apps/` — Layer 1 GitOps manifests (one directory per service)
 - `k8s/apps/argocd/` — App of Apps: AppProjects + Application CRs
-- `skills/` — OpenClaw skills (also useful reference for Cursor)
+- `skills/` — OpenClaw skills (mounted into pod at `/skills`)
 - `agents/workspaces/` — OpenClaw agent AGENTS.md personalities
+- `.cursor/skills/` — Cursor-local skills (git-workflow, documentation, release-management, secret-management, incident-response)
+- `.cursor/agents/` — Cursor subagents (verifier)
+- `.cursor/commands/` — Cursor commands (address-issue, pre-merge-check)
 - `docs/` — MkDocs documentation site
+
+## Available Skills and Commands
+
+| Invoke | Purpose |
+|---|---|
+| `/git-workflow` | Branch workflow, PR creation, post-merge cleanup |
+| `/documentation` | Doc update matrix, README structure, new service checklist |
+| `/release-management` | Release checklist, versioning, milestone lifecycle |
+| `/secret-management` | Infisical → ESO pipeline, add/rotate secrets |
+| `/incident-response` | Triage, rollback, ArgoCD recovery, post-incident docs |
+| `/address-issue` | Full issue-to-PR workflow (command) |
+| `/pre-merge-check` | Validate manifests, Helm keys, docs before merge (command) |
+| `/verifier` | Post-deploy health verification (subagent) |

--- a/.cursor/rules/kubernetes.mdc
+++ b/.cursor/rules/kubernetes.mdc
@@ -29,7 +29,7 @@ When creating or editing Application CRs, follow the rules in `k8s/apps/argocd/R
 
 ## Secrets
 
-Never put secret values in manifests. Use an `ExternalSecret` resource that references keys from Infisical. See `skills/secret-management/SKILL.md` for the pattern.
+Never put secret values in manifests. Use an `ExternalSecret` resource that references keys from Infisical. Use the `/secret-management` skill for the pattern.
 
 ## Kustomize
 
@@ -63,7 +63,7 @@ When adding `securityContext` to a deployment:
 
 ## Rollback
 
-All rollbacks go through git (revert commit → push → ArgoCD syncs). Never rely solely on `kubectl rollout undo` — ArgoCD will overwrite it. See `skills/incident-response/SKILL.md` for the full procedure. Quick reference:
+All rollbacks go through git (revert commit → push → ArgoCD syncs). Never rely solely on `kubectl rollout undo` — ArgoCD will overwrite it. Use the `/incident-response` skill for the full procedure. Quick reference:
 
 ```bash
 git revert <bad-commit> -m 1 --no-edit && git push origin main

--- a/.cursor/skills/documentation/SKILL.md
+++ b/.cursor/skills/documentation/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: documentation
+description: Documentation conventions, update matrix, README structure, and doc freshness tracking for the homelab. Use when adding services, updating manifests, or any change that requires doc updates.
+---
+
+# Documentation
+
+After every implementation, update the related documentation before considering the task complete. This is not optional.
+
+## Doc Freshness Tracking
+
+The repo uses `.doc-manifest.yml` to map every documentation file to its implementation sources. Before creating a PR, run:
+
+```bash
+python scripts/doc-freshness.py --check-pr    # which docs this branch should update
+python scripts/doc-freshness.py --stale       # full staleness report
+```
+
+The `doc-freshness` GitHub Actions workflow runs on every PR and will comment if mapped docs are missing updates. The manifest is the **source of truth** for doc-to-source relationships — when adding a new service or doc, add an entry to `.doc-manifest.yml`.
+
+## Single Source of Truth: `k8s/apps/<service>/README.md`
+
+Every service directory under `k8s/apps/` **must** have a `README.md`. This README is the **single source of truth** for that service's documentation. The corresponding `docs/<service>.md` is always a thin MkDocs wrapper that includes the README:
+
+```markdown
+---
+title: <Service Name>
+---
+
+{%
+   include-markdown "../k8s/apps/<service>/README.md"
+%}
+```
+
+**Never write documentation directly in `docs/<service>.md`** for services that have a `k8s/apps/<service>/` directory. Always edit the README instead.
+
+## README Structure
+
+Every `k8s/apps/<service>/README.md` should include these sections (adapt as needed):
+
+1. **Title + one-line description** — what the service does
+2. **Architecture** — mermaid diagram showing the service's components and connections
+3. **Directory Contents** — table listing every file in the directory and its purpose
+4. **Configuration** — key settings, Helm values, or Kustomize details
+5. **Secrets in Infisical** — table of secret keys the service consumes (if any)
+6. **Networking** — table with container port, NodePort, Tailscale port, and access URL
+7. **Operational Commands** — common kubectl commands for the service
+8. **Troubleshooting** — table of symptom / cause / fix
+
+## What to Update
+
+| Change area | Docs to update |
+|---|---|
+| `k8s/apps/<service>/` manifests | `k8s/apps/<service>/README.md` (the single source of truth) |
+| `k8s/apps/argocd/` (projects, applications) | `k8s/apps/argocd/README.md`, `docs/architecture.md` (Layer 1 diagram / service map) |
+| `terraform/` | `docs/bootstrap.md`, `docs/architecture.md` (Layer 0 section) |
+| `skills/` or `agents/` or `k8s/apps/openclaw/` | `k8s/apps/openclaw/README.md`, `docs/ai-agents.md` |
+| Secrets pipeline (ExternalSecret, Infisical) | `docs/secret-management.md` |
+| Networking (Tailscale, services, ports) | `docs/networking.md` |
+| New service added | See "Adding a new service" checklist below |
+| **Release milestone** | Review and update root `README.md` (invoke `/release-management`) |
+
+## Adding a New Service (documentation checklist)
+
+1. Create `k8s/apps/<service>/README.md` following the README structure above
+2. Create `docs/<service>.md` as a thin `include-markdown` wrapper (see template above)
+3. Add `<service>.md` to the `nav` in `mkdocs.yml`
+4. Add doc-to-source mapping to `.doc-manifest.yml`
+5. Update the service map and repository layout in `docs/architecture.md`
+6. Update root `README.md` — architecture diagram, repository structure, deployed services table, and documentation index
+7. If the service has secrets, update `docs/secret-management.md` and `k8s/apps/infisical/README.md` inventory
+8. If the service has a Tailscale endpoint, update `docs/networking.md` and `docs/bootstrap.md` (Tailscale Serve commands)
+
+## Rules
+
+- Keep docs concise — document the *what* and *why*, not step-by-step kubectl commands.
+- Never remove documentation for existing services without explicit instruction.
+- **Always include doc changes in the same commit as the implementation** (or as a follow-up commit in the same push). Pushing to `main` triggers the GitHub Pages deploy workflow, so docs go live automatically — but only if they are committed and pushed.

--- a/.cursor/skills/git-workflow/SKILL.md
+++ b/.cursor/skills/git-workflow/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: git-workflow
+description: Git workflow for the homelab repo. Branch creation, PR workflow, post-merge cleanup, and pre-merge validation. Use when making any changes that need to be committed, pushed, or merged.
+---
+
+# Git Workflow
+
+The `main` branch is **protected**. Never push directly to `main` — all changes require a feature branch and a pull request.
+
+## Issue-First Planning (mandatory)
+
+When addressing a GitHub issue (whether assigned by a user, picked from the backlog, or self-created), **always plan before coding**:
+
+1. **Read the issue** — understand the requirements, acceptance criteria, and linked context
+2. **Draft an implementation plan** covering:
+   - Which files/services will be modified
+   - The approach and key design decisions
+   - Risks, dependencies, or open questions
+   - Docs that need updating (invoke `/documentation` for the matrix)
+3. **Comment the plan on the issue** using `gh issue comment`:
+   ```bash
+   gh issue comment <issue-number> --repo holdennguyen/homelab --body "$(cat <<'EOF'
+   ## Implementation Plan
+
+   **Approach:** <high-level summary>
+
+   **Files to change:**
+   - `<path>` — <what and why>
+
+   **Risks / open questions:**
+   - <any concerns>
+
+   **Docs to update:**
+   - <list from documentation matrix>
+   EOF
+   )"
+   ```
+4. **Wait for feedback** if the plan is non-trivial or the issue was filed by someone else — proceed immediately only for straightforward changes you filed yourself
+5. **Reference the plan** throughout implementation — commit messages and PR body should trace back to the plan
+
+## Branch Workflow
+
+1. **Start from latest main:**
+   ```bash
+   git checkout main && git pull origin main
+   git checkout -b <type>/<short-description>
+   ```
+   Branch prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `security/`
+
+2. **Make changes** (referencing the plan from the issue) and commit with conventional messages:
+   ```bash
+   git add <files>
+   git commit -m "<type>: <description>"
+   ```
+   Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `security`
+
+3. **Keep your branch up to date** — before every push:
+   ```bash
+   git fetch origin main
+   git merge origin/main --no-edit
+   ```
+
+4. **Push and create a PR:**
+   ```bash
+   git push -u origin HEAD
+   gh pr create --title "<type>: <description>" --body "<summary>"
+   ```
+
+## Post-Merge Cleanup
+
+**Never delete a branch until the merge is confirmed.** Always verify before cleanup:
+
+```bash
+gh pr view <number> --json state,mergedAt --jq '"state: \(.state), merged: \(.mergedAt // "NOT MERGED")"'
+```
+
+Only proceed with deletion if the output shows `state: MERGED` and a merge timestamp. If the PR was closed without merging, do NOT delete the branch — the commits are only on that branch.
+
+```bash
+git checkout main && git pull origin main
+git branch -d <branch-name>
+git push origin --delete <branch-name>
+```
+
+## Pre-Merge Validation (for K8s/Helm changes)
+
+Before merging PRs that modify cluster resources:
+- Verify Helm value keys exist: `helm show values <chart>` (see `kubernetes.mdc`)
+- Validate YAML: `kubectl apply --dry-run=client -f <file>`
+- Check container image compatibility with `securityContext` changes
+- Review ArgoCD sync wave dependencies
+
+## Rules
+
+- **Never push to `main` directly** — branch protection will reject it
+- **Never force-push to `main`** — this is destructive and irreversible
+- **Never delete a branch without verifying the PR was merged** — use `gh pr view` to confirm
+- One PR per logical change — don't bundle unrelated changes
+- Include documentation updates in the same PR as the implementation
+- Never commit secrets, API keys, or credentials
+- After merge, verify ArgoCD sync and pod health (for K8s changes)
+- If a merge causes service degradation, invoke `/incident-response` for rollback procedures

--- a/.cursor/skills/incident-response/SKILL.md
+++ b/.cursor/skills/incident-response/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: incident-response
+description: Incident response, rollback procedures, ArgoCD recovery, and post-incident documentation for the homelab cluster. Use when a deployment causes service degradation or when you need to roll back a change.
+---
+
+# Incident Response & Rollback
+
+Procedures for detecting, triaging, rolling back, and documenting incidents in the GitOps-managed homelab cluster.
+
+## Severity Classification
+
+| Severity | Criteria | Response Time |
+|---|---|---|
+| **SEV-1** | Multiple services down, data loss risk, security breach | Immediate |
+| **SEV-2** | Single service down or degraded, no data loss | Within 15 minutes |
+| **SEV-3** | Non-critical service degraded, workaround exists | Within 1 hour |
+| **SEV-4** | Cosmetic issue, no user impact | Next available cycle |
+
+## Phase 1: Detection & Triage
+
+```bash
+kubectl get applications -n argocd
+kubectl get pods -A | grep -v Running | grep -v Completed
+kubectl get events -A --sort-by='.lastTimestamp' --field-selector type!=Normal | tail -30
+kubectl describe pod <crashing-pod> -n <namespace>
+kubectl logs -n <namespace> deploy/<name> --tail=100
+```
+
+**Triage checklist:**
+- Which services are affected? (blast radius)
+- What was the last change merged to `main`? (`git log -5 --oneline`)
+- Are pods crashing (`CrashLoopBackOff`) or stuck (`Pending`/`Progressing`)?
+- Is the issue caused by the new change or a pre-existing condition?
+- Severity classification (SEV-1 through SEV-4)
+
+## Phase 2: Rollback
+
+Roll back immediately if:
+- A service is in `CrashLoopBackOff` after a merge
+- ArgoCD shows `Degraded` for any application
+- Health checks or endpoints are unreachable
+
+### Option A: Git revert (preferred)
+
+```bash
+git log --oneline -10
+git revert <bad-commit-sha> -m 1 --no-edit
+git push origin main
+```
+
+### Option B: File-level restore (multi-commit)
+
+```bash
+git checkout <known-good-sha> -- path/to/file1.yaml path/to/file2.yaml
+git commit -m "revert: restore files to pre-<description> state"
+git push origin main
+```
+
+### Option C: Emergency kubectl override (SEV-1 only)
+
+```bash
+kubectl rollout undo deployment/<name> -n <namespace>
+```
+
+Always follow up with a proper git revert — kubectl changes are temporary (ArgoCD overwrites within ~3 minutes).
+
+## Phase 3: ArgoCD Recovery
+
+```bash
+# Force hard refresh on all applications
+for app in $(kubectl get applications -n argocd -o jsonpath='{.items[*].metadata.name}'); do
+  kubectl patch application "$app" -n argocd \
+    --type merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
+done
+
+# Cancel stuck sync
+kubectl patch application <app-name> -n argocd \
+  --type json -p '[{"op":"remove","path":"/operation"}]'
+
+# Force-delete crashing pod
+kubectl delete pod <crashing-pod> -n <namespace> --force --grace-period=0
+```
+
+## Phase 4: Post-Rollback Verification
+
+```bash
+kubectl get applications -n argocd
+kubectl get pods -A | grep -v Running | grep -v Completed
+kubectl get externalsecrets -A
+curl -sf http://localhost:30300/api/v1/version   # Gitea
+curl -sf http://localhost:30789/health            # OpenClaw
+kubectl get events -A --sort-by='.lastTimestamp' --field-selector type!=Normal | tail -10
+```
+
+All checks must pass before the rollback is considered complete.
+
+## Post-Incident Documentation
+
+After every incident (SEV-1 through SEV-3), document on the related GitHub issue or PR:
+
+1. **Timeline** — chronological events (merge, detection, triage, rollback, recovery)
+2. **Root cause** — the specific technical cause
+3. **Blast radius** — which services, for how long
+4. **Resolution** — revert commit SHA, manual steps
+5. **Lessons learned** — what could have prevented this
+6. **Action items** — concrete follow-up tasks
+
+## Post-Incident Cleanup
+
+1. **Reopen the original issue** — the revert means the feature was NOT delivered
+2. **Label the reverted PR** with `status:reverted`
+3. **Assign milestones** — original issue to future milestone, reverted PR stays in current
+4. **Create per-service sub-issues** for re-implementation
+5. **Triage sibling PRs** — close unreviewed PRs from the same batch
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `git revert` has conflicts | Use file-level restore (Option B) |
+| ArgoCD stuck `Progressing` | Cancel operation + force-delete pod |
+| Revert pushed but ArgoCD not syncing | Force hard refresh on all applications |
+| `kubectl rollout undo` reverted by ArgoCD | Push git revert ASAP; kubectl undo is temporary |
+| Helm values silently ignored | Verify keys with `helm show values` before PRs |

--- a/.cursor/skills/release-management/SKILL.md
+++ b/.cursor/skills/release-management/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: release-management
+description: Release checklist, version tagging, doc freshness sweep, and root README review. Use when cutting a new release or preparing a milestone for release.
+disable-model-invocation: true
+---
+
+# Release Management
+
+Before tagging a new release (e.g. `v1.1.0`), complete every item in this checklist.
+
+## Pre-Release Checklist
+
+1. **All milestone PRs merged** — no open PRs targeting this release
+2. **ArgoCD health** — all applications `Synced` + `Healthy`:
+   ```bash
+   kubectl get applications -n argocd
+   ```
+3. **Doc freshness** — run and resolve any stale entries:
+   ```bash
+   python scripts/doc-freshness.py --stale
+   ```
+4. **Root README review** — the root `README.md` is the public face of the repo. It is tracked in `.doc-manifest.yml` with narrow sources (kustomization.yaml, mkdocs.yml), but those triggers only catch structural additions. Manually review and update:
+   - Architecture diagram — does it reflect all current namespaces and services?
+   - Repository structure — any new top-level directories or service directories?
+   - Deployed services table — any new services, changed ports, or removed services?
+   - Documentation index — does the table list every doc file?
+   - Quick Start / secrets table — any new secrets or changed bootstrap steps?
+   - Future Plans — move completed items out, add new plans
+5. **Run doc freshness again** after updates to confirm all clear:
+   ```bash
+   python scripts/doc-freshness.py --stale
+   ```
+6. **Tag and release:**
+   ```bash
+   git tag -a vX.Y.Z -m "release description" && git push origin vX.Y.Z
+   ```
+
+## Semantic Versioning
+
+The repo follows `vMAJOR.MINOR.PATCH`:
+
+| Condition | Bump |
+|---|---|
+| Any PR has `semver:breaking` label | **MAJOR** |
+| At least one `type:feat` (no breaking) | **MINOR** |
+| Only `type:fix` / `type:chore` / `type:docs` / `type:refactor` / `type:security` | **PATCH** |
+
+## Milestone Lifecycle
+
+```bash
+# Check for open milestones
+gh api repos/holdennguyen/homelab/milestones --jq '.[] | select(.state=="open") | .title' | head -1
+
+# Verify milestone completeness
+gh api repos/holdennguyen/homelab/milestones --jq '.[] | select(.title=="<version>") | "open: \(.open_issues), closed: \(.closed_issues)"'
+
+# Close milestone after release
+gh api repos/holdennguyen/homelab/milestones/<number> --method PATCH -f state="closed"
+
+# Create next milestone
+gh api repos/holdennguyen/homelab/milestones --method POST -f title="v<next>" -f description="<goal>"
+```

--- a/.cursor/skills/secret-management/SKILL.md
+++ b/.cursor/skills/secret-management/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: secret-management
+description: Manage secrets through the Infisical to External Secrets Operator to Kubernetes pipeline. Add, rotate, and troubleshoot secrets without storing them in git.
+---
+
+# Secret Management
+
+All secrets flow through: Infisical (source of truth) → ESO (sync) → K8s Secret (consumed by pods). Secrets never live in git.
+
+## Adding a Secret for a Service
+
+1. Add the key/value to Infisical UI under `homelab / prod`
+2. Add an entry to the service's `external-secret.yaml`:
+   ```yaml
+   - secretKey: MY_KEY
+     remoteRef:
+       key: MY_KEY
+   ```
+3. Add the env var to the service's `deployment.yaml`:
+   ```yaml
+   - name: MY_KEY
+     valueFrom:
+       secretKeyRef:
+         name: <service>-secret
+         key: MY_KEY
+   ```
+4. Push to `main` — ArgoCD syncs, ESO creates the K8s Secret
+
+## Rotating a Secret
+
+1. Update the value in Infisical
+2. Force ESO re-sync:
+   ```bash
+   kubectl annotate externalsecret <name> -n <ns> force-sync=$(date +%s) --overwrite
+   ```
+3. Restart the consuming deployment:
+   ```bash
+   kubectl rollout restart deployment/<name> -n <ns>
+   ```
+
+## Checking Secret Health
+
+```bash
+kubectl get clustersecretstore infisical
+kubectl describe clustersecretstore infisical
+kubectl get externalsecret -A
+kubectl get secret <name> -n <ns> -o jsonpath='{.data.<KEY>}' | base64 -d
+```
+
+## Current Secrets
+
+| ExternalSecret | Namespace | Keys |
+|---|---|---|
+| `postgresql-secret` | `gitea-system` | POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_DB, GITEA_DB_PASSWORD |
+| `gitea-secret` | `gitea-system` | GITEA_SECRET_KEY |
+| `gitea-admin-secret` | `gitea-system` | GITEA_ADMIN_USERNAME, GITEA_ADMIN_PASSWORD, GITEA_ADMIN_EMAIL |
+| `openclaw-secret` | `openclaw` | OPENCLAW_GATEWAY_TOKEN, OPENROUTER_API_KEY, GEMINI_API_KEY |
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `InvalidProviderConfig` on ClusterSecretStore | Check Infisical machine identity credentials |
+| 401 Unauthorized | Update clientId/clientSecret in `terraform.tfvars`, run `terraform apply` |
+| 403 Forbidden | Add machine identity to the `homelab` project in Infisical |
+| ExternalSecret stuck `SecretSyncedError` | Force re-sync with annotation |


### PR DESCRIPTION
## Summary
- Set up Cursor's native skills, subagents, and commands following [official docs](https://cursor.com/docs/context/skills)
- Slimmed `homelab.mdc` from **224 lines to 53 lines** — procedural content moved to on-demand skills
- Context is now loaded progressively instead of bloating every conversation

### New files

**Skills** (`.cursor/skills/`) — agent auto-invokes or user invokes with `/name`:
- `git-workflow` — branch workflow, PR creation, post-merge cleanup
- `documentation` — doc matrix, README structure, new service checklist
- `release-management` — release checklist, versioning (`disable-model-invocation: true`)
- `secret-management` — Infisical → ESO pipeline
- `incident-response` — triage, rollback, ArgoCD recovery

**Subagents** (`.cursor/agents/`):
- `verifier` — post-deploy health verification (background, fast model)

**Commands** (`.cursor/commands/`):
- `address-issue` — full issue-to-PR workflow
- `pre-merge-check` — validate manifests, Helm keys, docs

### Modified files
- `.cursor/rules/homelab.mdc` — slimmed from 224 to 53 lines, references skills instead of inlining procedures
- `.cursor/rules/kubernetes.mdc` — updated `skills/` file path references to `/skill-name` invocations

## Test plan
- [ ] Verify skills appear in Cursor Settings → Rules → Agent Decides section
- [ ] Verify `/address-issue` and `/pre-merge-check` appear when typing `/` in chat
- [ ] Verify `/verifier` subagent is available

Made with [Cursor](https://cursor.com)