### PR TITLE
security: replace SSH deploy key with HTTPS for ArgoCD repo access

### DIFF
--- a/.cursor/rules/terraform.mdc
+++ b/.cursor/rules/terraform.mdc
@@ -13,7 +13,7 @@ Terraform manages Layer 0 only — the bootstrap layer that creates ArgoCD and i
 - ArgoCD Helm release and configuration
 - Root Application CR (`argocd-apps`) and Infisical Application CR
 - Bootstrap K8s Secrets (Infisical encryption key, auth secret, machine identity)
-- ArgoCD SSH deploy key for the private GitHub repo
+- ArgoCD root Application and Infisical Application CRs
 
 ## Rules
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -41,7 +41,7 @@ flowchart TD
 ## Step 1: Clone the Repository
 
 ```bash
-git clone git@github.com:holdennguyen/homelab.git
+git clone https://github.com/holdennguyen/homelab.git
 cd homelab
 ```
 
@@ -63,29 +63,7 @@ openssl rand -hex 12
 openssl rand -hex 12
 ```
 
-## Step 3: Set Up SSH Deploy Key
-
-ArgoCD needs read-only access to the private GitHub repository. You can use your machine's existing SSH key if it is already authorized for the GitHub account:
-
-```bash
-# Check if an ed25519 key exists
-ls -la ~/.ssh/id_ed25519
-
-# If it exists, display the public key to verify it is in GitHub → Settings → SSH Keys
-cat ~/.ssh/id_ed25519.pub
-```
-
-Alternatively, create a dedicated deploy key with read-only access:
-
-```bash
-ssh-keygen -t ed25519 -f ~/.ssh/homelab-argocd -N "" -C "argocd@homelab"
-
-# Add the public key to GitHub:
-# Repository → Settings → Deploy keys → Add deploy key (read-only)
-cat ~/.ssh/homelab-argocd.pub
-```
-
-## Step 4: Create `terraform/terraform.tfvars`
+## Step 3: Create `terraform/terraform.tfvars`
 
 Copy the example file:
 
@@ -96,9 +74,8 @@ cp terraform/terraform.tfvars.example terraform/terraform.tfvars
 Then populate every value (the file is gitignored — it never gets committed):
 
 ```hcl
-kube_context     = "orbstack"
-argocd_version   = "7.8.0"
-homelab_repo_url = "git@github.com:holdennguyen/homelab.git"
+kube_context   = "orbstack"
+argocd_version = "7.8.0"
 
 # From Step 2
 infisical_encryption_key    = "<output of: openssl rand -hex 16>"
@@ -106,17 +83,10 @@ infisical_auth_secret       = "<output of: openssl rand -base64 32>"
 infisical_postgres_password = "<output of: openssl rand -hex 12>"
 infisical_redis_password    = "<output of: openssl rand -hex 12>"
 
-# From Infisical UI after first run (see Step 6)
+# From Infisical UI after first run (see Step 5)
 # Leave placeholder values for the first apply and update after Infisical starts
 infisical_machine_identity_client_id     = "placeholder-update-after-infisical-starts"
 infisical_machine_identity_client_secret = "placeholder-update-after-infisical-starts"
-
-# From Step 3
-argocd_repo_ssh_private_key = <<-EOT
------BEGIN OPENSSH PRIVATE KEY-----
-<paste full private key content here>
------END OPENSSH PRIVATE KEY-----
-EOT
 
 # ArgoCD OIDC client secret (create Authentik provider with client_id=argocd after bootstrap)
 argocd_oidc_client_secret = "<leave placeholder, set after Authentik is running>"
@@ -124,7 +94,7 @@ argocd_oidc_client_secret = "<leave placeholder, set after Authentik is running>
 
 > **Note on machine identity credentials:** On the first `terraform apply`, you can use placeholder values for `infisical_machine_identity_client_id` and `infisical_machine_identity_client_secret`. After Infisical is running and you have created a real Machine Identity (Step 6), re-run `terraform apply` with the real values.
 
-## Step 5: Bootstrap with Terraform
+## Step 4: Bootstrap with Terraform
 
 ```bash
 cd terraform
@@ -142,7 +112,7 @@ terraform apply
 Terraform creates the following in order:
 1. Namespaces: `argocd`, `infisical`, `external-secrets`
 2. ArgoCD Helm release (NodePort :30080/:30443)
-3. Bootstrap K8s Secrets: `infisical-secrets`, `infisical-helm-secrets`, `infisical-machine-identity`, `repo-homelab`
+3. Bootstrap K8s Secrets: `infisical-secrets`, `infisical-helm-secrets`, `infisical-machine-identity`
 4. ArgoCD `Application` CR for the root App of Apps (`argocd-apps`)
 5. ArgoCD `Application` CR for Infisical (with embedded Helm values)
 
@@ -162,7 +132,7 @@ Expected sequence:
 3. `external-secrets-config` app syncs (sync-wave 1) → ClusterSecretStore is created
 4. `postgresql`, `gitea`, `monitoring`, `authentik` sync → pods start (secrets not yet available)
 
-## Step 6: Configure Infisical
+## Step 5: Configure Infisical
 
 This step is done once in the Infisical web UI. Infisical cannot configure itself automatically.
 
@@ -261,7 +231,7 @@ kubectl annotate externalsecret postgresql-secret -n gitea-system force-sync=$(d
 kubectl annotate externalsecret gitea-secret -n gitea-system force-sync=$(date +%s) --overwrite
 ```
 
-## Step 7: Configure Tailscale Serve
+## Step 6: Configure Tailscale Serve
 
 These commands expose services to all devices on your tailnet with automatic TLS:
 
@@ -313,7 +283,7 @@ https://holdens-mac-mini.story-larch.ts.net:8447 (tailnet only)
 |-- / proxy http://localhost:30789
 ```
 
-## Step 8: Verify Everything is Healthy
+## Step 7: Verify Everything is Healthy
 
 ```bash
 # ArgoCD — all applications should be Synced + Healthy

--- a/k8s/apps/argocd/README.md
+++ b/k8s/apps/argocd/README.md
@@ -11,7 +11,6 @@ flowchart TD
     subgraph terraform["Terraform (bootstrap, run once)"]
         TF["terraform apply"]
         TF --> HelmRelease["helm_release: argocd\nargo-cd v7.8.0\nNodePort :30080"]
-        TF --> RepoCred["K8s Secret: repo-homelab\nSSH key for GitHub"]
         TF --> RootApp["Application: argocd-apps\n→ k8s/apps/argocd/"]
         TF --> InfisicalApp["Application: infisical\n(Helm values embedded in Terraform)"]
     end
@@ -128,13 +127,13 @@ ArgoCD runs in **insecure mode** (`server.insecure = true`) — it serves plain 
 
 ## Repository Authentication
 
-ArgoCD authenticates to the private GitHub repository using an SSH deploy key. The key is stored in a Kubernetes Secret `repo-homelab` in the `argocd` namespace, created by Terraform. All Application CRs use the SSH URL format:
+The homelab repository is public on GitHub. ArgoCD clones it via unauthenticated HTTPS — no deploy keys, PATs, or credentials are needed. All Application CRs use the HTTPS URL format:
 
 ```
-repoURL: git@github.com:holdennguyen/homelab.git
+repoURL: https://github.com/holdennguyen/homelab.git
 ```
 
-The SSH key is stored in `terraform/terraform.tfvars` (gitignored) and injected by `terraform/argocd.tf`.
+This eliminates the risk of SSH private key leakage in the public repo's Terraform state or tfvars. If the repo ever goes private, a Fine-grained PAT can be added via the Infisical → ESO pipeline.
 
 ## Adding a New Application
 
@@ -183,7 +182,7 @@ metadata:
 spec:
   project: <project>                            # secrets | data | apps
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/my-service
   destination:
@@ -254,8 +253,7 @@ kubectl logs -n argocd deploy/argocd-application-controller --tail=50
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| App shows `OutOfSync` forever | ArgoCD can't clone repo | Check `repo-homelab` secret exists; verify SSH key is authorized on GitHub |
-| `authentication required` error | SSH key not authorized | Confirm public key is in GitHub → repo → Settings → Deploy keys |
+| App shows `OutOfSync` forever | ArgoCD can't clone repo | Verify the HTTPS URL is reachable: `git ls-remote https://github.com/holdennguyen/homelab.git` |
 | Application stuck in `Progressing` | Pod not ready | `kubectl describe pod -n <namespace>` for Events |
 | CRD not found during sync | Wrong sync wave order | Ensure `external-secrets` (wave 0) is healthy before `external-secrets-config` (wave 1) syncs |
 | Changes not deployed after push | Normal poll delay | Wait ~3min or force refresh via annotation |

--- a/k8s/apps/argocd/applications/authentik-config-app.yaml
+++ b/k8s/apps/argocd/applications/authentik-config-app.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   project: apps
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/authentik
   destination:

--- a/k8s/apps/argocd/applications/external-secrets-config-app.yaml
+++ b/k8s/apps/argocd/applications/external-secrets-config-app.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   project: secrets
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/external-secrets
   destination:

--- a/k8s/apps/argocd/applications/gitea-app.yaml
+++ b/k8s/apps/argocd/applications/gitea-app.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: apps
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/gitea
   destination:

--- a/k8s/apps/argocd/applications/monitoring-config-app.yaml
+++ b/k8s/apps/argocd/applications/monitoring-config-app.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: apps
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/monitoring
   destination:

--- a/k8s/apps/argocd/applications/namespace-security-app.yaml
+++ b/k8s/apps/argocd/applications/namespace-security-app.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/namespace-security
   destination:

--- a/k8s/apps/argocd/applications/networking-policies-app.yaml
+++ b/k8s/apps/argocd/applications/networking-policies-app.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/networking-policies
   destination:

--- a/k8s/apps/argocd/applications/openclaw-app.yaml
+++ b/k8s/apps/argocd/applications/openclaw-app.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: apps
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/openclaw
   destination:

--- a/k8s/apps/argocd/applications/postgresql-app.yaml
+++ b/k8s/apps/argocd/applications/postgresql-app.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: data
   source:
-    repoURL: git@github.com:holdennguyen/homelab.git
+    repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD
     path: k8s/apps/postgresql
   destination:

--- a/k8s/apps/argocd/projects/apps.yaml
+++ b/k8s/apps/argocd/projects/apps.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   description: User-facing applications and services
   sourceRepos:
-    - git@github.com:holdennguyen/homelab.git
+    - https://github.com/holdennguyen/homelab.git
     - https://prometheus-community.github.io/helm-charts
     - https://charts.goauthentik.io
     - https://aquasecurity.github.io/helm-charts

--- a/k8s/apps/argocd/projects/data.yaml
+++ b/k8s/apps/argocd/projects/data.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   description: Databases and persistent data stores
   sourceRepos:
-    - git@github.com:holdennguyen/homelab.git
+    - https://github.com/holdennguyen/homelab.git
   destinations:
     - server: https://kubernetes.default.svc
       namespace: gitea-system

--- a/k8s/apps/argocd/projects/secrets.yaml
+++ b/k8s/apps/argocd/projects/secrets.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   description: Secret management infrastructure (ESO, Infisical)
   sourceRepos:
-    - git@github.com:holdennguyen/homelab.git
+    - https://github.com/holdennguyen/homelab.git
     - https://charts.external-secrets.io
     - https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
   destinations:

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -450,7 +450,7 @@ kubectl rollout restart deployment/openclaw -n openclaw
 When cloning the homelab repo on a new machine, the submodule directory will be empty by default. Initialize it with:
 
 ```bash
-git clone git@github.com:holdennguyen/homelab.git
+git clone https://github.com/holdennguyen/homelab.git
 cd homelab
 git submodule update --init
 ```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,7 +16,6 @@ flowchart TD
 
     subgraph argocd_resources["ArgoCD resources"]
         Helm["helm_release: argocd\nargo-cd chart v7.8.0\nNodePort :30080/:30443"]
-        RepoCred["kubernetes_secret: repo-homelab\nSSH deploy key for GitHub"]
         InfisicalApp["null_resource: infisical application CR\nHelm chart with embedded postgres/redis passwords"]
         RootApp["null_resource: argocd-apps root Application\nApp of Apps → k8s/apps/argocd/"]
     end
@@ -32,7 +31,6 @@ flowchart TD
     TF --> secrets
 
     Helm -->|depends_on| NS1
-    RepoCred -->|depends_on| Helm
     InfisicalApp -->|depends_on| Helm
     RootApp -->|depends_on| Helm
     S1 -->|depends_on| NS2
@@ -44,7 +42,7 @@ flowchart TD
 | File | Purpose |
 |---|---|
 | `providers.tf` | Configures `kubernetes`, `helm`, `local`, and `null` providers pointing to the `orbstack` kubeconfig context |
-| `argocd.tf` | ArgoCD Helm release, Infisical Application CR, root App of Apps, SSH repo credential |
+| `argocd.tf` | ArgoCD Helm release, Infisical Application CR, root App of Apps |
 | `bootstrap-secrets.tf` | Namespaces and the three bootstrap K8s Secrets |
 | `variables.tf` | All variable declarations with descriptions and types |
 | `outputs.tf` | Post-apply instructions and access URLs |
@@ -60,8 +58,7 @@ All variables are documented in `variables.tf`. The table below provides the com
 |---|---|---|---|---|
 | `kube_context` | string | no | `"orbstack"` | kubeconfig context name |
 | `argocd_version` | string | no | `"7.8.0"` | ArgoCD Helm chart version |
-| `homelab_repo_url` | string | no | `"git@github.com:holdennguyen/homelab.git"` | SSH URL of the homelab git repo |
-| `argocd_repo_ssh_private_key` | string | **yes** | — | SSH private key for ArgoCD to clone the homelab repo |
+| `homelab_repo_url` | string | no | `"https://github.com/holdennguyen/homelab.git"` | HTTPS URL of the homelab git repo |
 | `argocd_oidc_client_secret` | string | **yes** | — | OIDC client secret for ArgoCD's Authentik SSO provider |
 | `infisical_encryption_key` | string | **yes** | — | 32-char hex string; Infisical encrypts all stored secrets with this |
 | `infisical_auth_secret` | string | **yes** | — | Base64 string; Infisical JWT signing secret |
@@ -130,14 +127,6 @@ See [docs/bootstrap.md](../docs/bootstrap.md) for the complete step-by-step guid
    argocd_oidc_client_secret = "<new-secret>"
    ```
 3. `terraform apply` — Helm updates `argocd-secret` with the new OIDC secret. ArgoCD picks it up on the next login (no pod restart needed).
-
-### Rotate the ArgoCD SSH Deploy Key
-
-1. Generate a new key: `ssh-keygen -t ed25519 -f /tmp/argocd-new -N "" -C "argocd@homelab"`
-2. Add the public key to GitHub: **repo → Settings → Deploy keys → Add (read-only)**
-3. Update `terraform.tfvars` with the new private key content
-4. `terraform apply` — updates the `repo-homelab` K8s Secret
-5. Remove the old public key from GitHub
 
 ### Rotate Infisical Bootstrap Secrets
 

--- a/terraform/argocd.tf
+++ b/terraform/argocd.tf
@@ -190,31 +190,6 @@ resource "null_resource" "infisical_app" {
   depends_on = [helm_release.argocd, local_file.infisical_app]
 }
 
-# ── ArgoCD repository credential ──────────────────────────────────────────────
-# ArgoCD needs this to clone the private GitHub repo.
-# The Secret label argocd.argoproj.io/secret-type=repository tells ArgoCD to
-# treat it as a repository credential.
-
-resource "kubernetes_secret" "argocd_repo_credential" {
-  metadata {
-    name      = "repo-homelab"
-    namespace = kubernetes_namespace.argocd.metadata[0].name
-    labels = {
-      "argocd.argoproj.io/secret-type" = "repository"
-    }
-  }
-
-  data = {
-    type          = "git"
-    url           = var.homelab_repo_url
-    sshPrivateKey = var.argocd_repo_ssh_private_key
-  }
-
-  type = "Opaque"
-
-  depends_on = [helm_release.argocd]
-}
-
 # ── Root Application (App of Apps) ─────────────────────────────────────────────
 # We use null_resource + local-exec instead of kubernetes_manifest because
 # kubernetes_manifest validates the schema against the live API at plan time,

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,19 +1,8 @@
 # Copy this file to terraform.tfvars and fill in real values.
 # terraform.tfvars is gitignored — never commit it.
 
-# SSH private key for the ArgoCD deploy key.
-# 1. Generate: ssh-keygen -t ed25519 -f /tmp/argocd-deploy-key -N "" -C "argocd@homelab"
-# 2. Add the PUBLIC key to GitHub: repo → Settings → Deploy keys → Add deploy key (read-only)
-# 3. Paste the PRIVATE key below (multiline value in quotes).
-argocd_repo_ssh_private_key = <<-EOT
-  -----BEGIN OPENSSH PRIVATE KEY-----
-  REPLACE_WITH_PRIVATE_KEY_CONTENTS
-  -----END OPENSSH PRIVATE KEY-----
-EOT
-
 kube_context     = "orbstack"
 argocd_version   = "7.8.0"
-homelab_repo_url = "git@github.com:holdennguyen/homelab.git"
 
 # Generate: openssl rand -hex 16
 infisical_encryption_key = "REPLACE_WITH_32_CHAR_HEX"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,9 +1,3 @@
-variable "argocd_repo_ssh_private_key" {
-  description = "SSH private key for the ArgoCD deploy key (read-only access to the homelab repo)"
-  type        = string
-  sensitive   = true
-}
-
 variable "argocd_oidc_client_secret" {
   description = "OIDC client secret for ArgoCD's Authentik provider"
   type        = string
@@ -23,9 +17,9 @@ variable "argocd_version" {
 }
 
 variable "homelab_repo_url" {
-  description = "Git repository SSH URL for the homelab GitOps source"
+  description = "Git repository HTTPS URL for the homelab GitOps source"
   type        = string
-  default     = "git@github.com:holdennguyen/homelab.git"
+  default     = "https://github.com/holdennguyen/homelab.git"
 }
 
 # ── Infisical bootstrap secrets ───────────────────────────────────────────────


### PR DESCRIPTION
Closes #56

## Summary
- Switch all ArgoCD repo URLs from SSH (`git@github.com:...`) to HTTPS (`https://github.com/...`)
- Remove the SSH deploy key infrastructure entirely: `kubernetes_secret.argocd_repo_credential`, `argocd_repo_ssh_private_key` variable, deploy key from GitHub
- Since the repo is public, no credentials are needed — eliminates the risk of SSH private key leakage via Terraform state or tfvars
- Updated 8 Application CRs, 3 AppProjects, Terraform config, and all related documentation

## Why
The SSH private key stored in `terraform.tfstate` (plaintext) posed a secret scanning risk on this **public** repository. An accidental commit of the state file would trigger GitHub to revoke the deploy key, breaking all Git-sourced ArgoCD apps — exactly what happened recently.

## Post-merge steps
- [ ] Run `terraform apply` on the host to sync Terraform state (removes the deleted `repo-homelab` resource)
- [ ] Verify all ArgoCD apps remain Synced/Healthy

## Test plan
- [x] Deployed HTTPS URL to live cluster — all 14 apps Synced/Healthy
- [x] Removed SSH deploy key from GitHub — no impact
- [x] Deleted `repo-homelab` K8s secret — ArgoCD continues to sync via HTTPS
- [ ] `terraform plan` shows clean removal of SSH key resources


Made with [Cursor](https://cursor.com)