### PR TITLE
docs: remove remaining SSH deploy key references after HTTPS migration

### DIFF
--- a/agents/workspaces/security-analyst/AGENTS.md
+++ b/agents/workspaces/security-analyst/AGENTS.md
@@ -15,7 +15,7 @@ You are a security specialist responsible for the security posture of Holden's h
 - Secrets in Infisical, synced via ESO (never in git)
 - Network access restricted to Tailscale tailnet
 - Bootstrap credentials in Terraform tfvars (gitignored)
-- ArgoCD SSH deploy key for private GitHub repo
+- ArgoCD clones repo via unauthenticated HTTPS (public repo, no credentials stored)
 
 ## Responsibilities
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,6 @@ Terraform bootstraps the cluster exactly once. After `terraform apply`, no more 
 | `infisical-secrets` K8s Secret | `infisical` namespace | Contains `ENCRYPTION_KEY` + `AUTH_SECRET` — Infisical needs these before it can run, so they can't come from Infisical |
 | `infisical-helm-secrets` K8s Secret | `argocd` namespace | Postgres + Redis passwords for the Infisical Helm chart. ArgoCD `Application` CRs don't support `valuesFrom` referencing K8s Secrets, so Terraform injects them via `helm.valuesObject` |
 | `infisical-machine-identity` K8s Secret | `external-secrets` namespace | ESO uses this to authenticate to Infisical. Terraform owns it so the credential can be rotated with `terraform apply` |
-| `repo-homelab` K8s Secret | `argocd` namespace | SSH deploy key for ArgoCD to clone the private GitHub repo |
 | ArgoCD root Application (`argocd-apps`) | `argocd` namespace | Triggers the App of Apps — the root of all GitOps |
 | ArgoCD Infisical Application (`infisical`) | `argocd` namespace | Created by Terraform because its Helm values embed sensitive credentials |
 
@@ -274,7 +273,7 @@ homelab/
 ├── terraform/                      # Layer 0 — bootstrap (run once)
 │   ├── README.md                   # Terraform variables and day-2 ops reference
 │   ├── providers.tf                # kubernetes + helm + local + null providers
-│   ├── argocd.tf                   # ArgoCD Helm release, Infisical App, root App, SSH credential
+│   ├── argocd.tf                   # ArgoCD Helm release, Infisical App, root App
 │   ├── bootstrap-secrets.tf        # K8s Secrets created from tfvars
 │   ├── variables.tf                # All variable declarations
 │   ├── outputs.tf                  # Post-apply instructions

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -12,7 +12,6 @@ This guide walks a new maintainer through setting up the homelab from a complete
 | `tailscale` | latest | [tailscale.com/download](https://tailscale.com/download) |
 | OrbStack | latest | [orbstack.dev](https://orbstack.dev) |
 | `openssl` | any | pre-installed on macOS |
-| `ssh-keygen` | any | pre-installed on macOS |
 
 Verify your cluster context:
 
@@ -334,7 +333,7 @@ terraform apply
 
 | Issue | Symptom | Fix |
 |---|---|---|
-| ArgoCD fails to pull repo | `App shows OutOfSync, authentication required` | Verify `argocd_repo_ssh_private_key` in tfvars is the correct private key authorized on GitHub |
+| ArgoCD fails to pull repo | `App shows OutOfSync` | Verify the HTTPS URL is reachable: `git ls-remote https://github.com/holdennguyen/homelab.git` |
 | Infisical CrashLoopBackOff | Pod restarts, DB migration errors in logs | PostgreSQL not ready yet — Kubernetes retries automatically. Wait ~2 minutes |
 | ESO ClusterSecretStore 401 | `InvalidProviderConfig: status-code=401` | Machine identity credentials are wrong or placeholders — re-run `terraform apply` with real values |
 | ExternalSecrets not syncing | `SecretSyncedError: ClusterSecretStore not ready` | ClusterSecretStore is still connecting — force refresh with annotate command |

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -20,7 +20,7 @@ flowchart TD
     end
 
     subgraph tfvars["terraform.tfvars (gitignored, local only)"]
-        TFVars["infisical_encryption_key\ninfisical_auth_secret\ninfisical_postgres_password\ninfisical_redis_password\ninfisical_machine_identity_client_id\ninfisical_machine_identity_client_secret\nargocd_repo_ssh_private_key\nargocd_oidc_client_secret"]
+        TFVars["infisical_encryption_key\ninfisical_auth_secret\ninfisical_postgres_password\ninfisical_redis_password\ninfisical_machine_identity_client_id\ninfisical_machine_identity_client_secret\nargocd_oidc_client_secret"]
     end
 
     subgraph tf["Terraform state"]
@@ -100,7 +100,6 @@ These secrets are the "chicken-and-egg" exceptions — they cannot come from Inf
 | `infisical-secrets` | `infisical` | `ENCRYPTION_KEY`, `AUTH_SECRET` | Infisical app encryption and session signing |
 | `infisical-helm-secrets` | `argocd` | `values.yaml` (YAML blob) | Postgres + Redis passwords passed to Infisical Helm chart via ArgoCD Application |
 | `infisical-machine-identity` | `external-secrets` | `clientId`, `clientSecret` | ESO authenticates to Infisical using this Universal Auth identity |
-| `repo-homelab` | `argocd` | `sshPrivateKey` | ArgoCD SSH key for cloning the private GitHub repo |
 | `argocd-secret` | `argocd` | `oidc.argocd.clientSecret` | ArgoCD OIDC client secret for Authentik SSO — set via Terraform `set_sensitive` Helm value. **Not** managed by ESO to avoid annotation-propagation conflicts. |
 
 ## Infisical Project Structure
@@ -299,21 +298,6 @@ ArgoCD's OIDC client secret for Authentik SSO is managed through Terraform Helm 
    cd terraform && terraform apply
    ```
    Helm updates `argocd-secret` with the new OIDC secret. ArgoCD picks it up on the next login — no pod restart required.
-
-### Rotating the ArgoCD SSH Deploy Key
-
-1. Generate a new key: `ssh-keygen -t ed25519 -f /tmp/new-argocd-key -N "" -C "argocd@homelab"`
-2. Add the new public key to GitHub: **repo → Settings → Deploy keys → Add deploy key** (read-only).
-3. Update `terraform/terraform.tfvars`:
-   ```hcl
-   argocd_repo_ssh_private_key = <<-EOT
-   -----BEGIN OPENSSH PRIVATE KEY-----
-   <paste new private key>
-   -----END OPENSSH PRIVATE KEY-----
-   EOT
-   ```
-4. Run `terraform apply`. The `repo-homelab` Secret in the `argocd` namespace is updated; ArgoCD picks it up within ~30 seconds.
-5. Remove the old public key from GitHub Deploy keys.
 
 ### Updating an Application Secret (e.g., Gitea's SECRET_KEY)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -189,7 +189,7 @@ flowchart LR
 | Control | Status | Details |
 |---|---|---|
 | Branch protection on `main` | Enforced | PRs require review; no direct push; linear history required |
-| ArgoCD SSH deploy key | Active | Read-only access to `holdennguyen/homelab` |
+| ArgoCD repo access (HTTPS) | Active | Unauthenticated HTTPS clone of public repo — no credentials stored |
 | ArgoCD self-heal | Enabled | Manual `kubectl` changes are reverted within ~3 minutes |
 | Helm chart version pinning | Enforced | All Application CRs pin `targetRevision` |
 | Container image scanning | Active | Trivy Operator (ClientServer mode) scans all running images |

--- a/skills/gitops/SKILL.md
+++ b/skills/gitops/SKILL.md
@@ -588,7 +588,7 @@ GitHub auto-generates release notes from merged PRs. The existing type and area 
 
 | Symptom | Fix |
 |---|---|
-| App stuck `OutOfSync` | Check ArgoCD can clone repo: `kubectl get secret repo-homelab -n argocd` |
+| App stuck `OutOfSync` | Verify repo access: `git ls-remote https://github.com/holdennguyen/homelab.git` |
 | App stuck `Progressing` | Pod not ready: `kubectl describe pod -n <ns>` |
 | CRD not found | Sync wave ordering issue: ensure wave 0 apps are healthy first |
 | Changes not deploying | Wait ~3min or force refresh via annotation |

--- a/skills/homelab-admin/SKILL.md
+++ b/skills/homelab-admin/SKILL.md
@@ -241,4 +241,4 @@ kubectl rollout restart deployment/openclaw -n openclaw
 | ExternalSecret SecretSyncedError | `kubectl describe externalsecret <name> -n <ns>` | Verify key exists in Infisical |
 | Service unreachable via Tailscale | `tailscale serve status` | Re-add the serve rule on the host |
 | Node not ready | `kubectl describe node orbstack` | Check OrbStack is running |
-| ArgoCD can't clone repo | `kubectl get secret repo-homelab -n argocd` | Check SSH deploy key |
+| ArgoCD can't clone repo | `git ls-remote https://github.com/holdennguyen/homelab.git` | Verify HTTPS URL is reachable |

--- a/skills/security-analyst/SKILL.md
+++ b/skills/security-analyst/SKILL.md
@@ -31,7 +31,7 @@ Assess and harden the security posture of the homelab cluster, applications, and
 - Secrets managed through Infisical → ESO pipeline (never in git)
 - Network access restricted to Tailscale tailnet (private)
 - Bootstrap credentials managed by Terraform (gitignored tfvars)
-- ArgoCD SSH deploy key for GitHub repo access
+- ArgoCD clones repo via unauthenticated HTTPS (public repo, no credentials stored)
 - All external access is HTTPS via Tailscale Serve with Let's Encrypt certificates
 - OrbStack does not support NetworkPolicy enforcement (CNI limitation)
 
@@ -174,7 +174,7 @@ kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metada
 | Control | Status | Notes |
 |---|---|---|
 | GitHub branch protection | Enforced | PRs require review, no direct push to main |
-| SSH deploy key (read-only) | Active | ArgoCD uses SSH key for repo clone |
+| HTTPS repo access (no credentials) | Active | ArgoCD clones public repo via unauthenticated HTTPS |
 | Signed commits | Not enforced | Consider enabling GPG signing for agent commits |
 | Dependabot / Renovate | Not configured | Consider for Helm chart version updates |
 | Image scanning | Manual | Consider adding Trivy or Grype to CI |


### PR DESCRIPTION
Follow-up to #57 (merged). Removes all remaining references to the old ArgoCD SSH deploy key across docs, skills, and agent configs.

## Summary
- **docs/architecture.md** — Removed `repo-homelab` K8s Secret from Terraform-managed resources table; updated `argocd.tf` file description
- **docs/bootstrap.md** — Removed `ssh-keygen` from prerequisites; updated troubleshooting to reference HTTPS
- **docs/secret-management.md** — Removed `argocd_repo_ssh_private_key` from mermaid diagram; removed `repo-homelab` from bootstrap secrets table; removed SSH key rotation section
- **docs/security.md** — Updated ArgoCD repo access row from "SSH deploy key" to "HTTPS (no credentials)"
- **skills/gitops/SKILL.md** — Updated troubleshooting to verify HTTPS URL instead of SSH secret
- **skills/homelab-admin/SKILL.md** — Same troubleshooting update
- **skills/security-analyst/SKILL.md** — Updated security posture table and context description
- **agents/workspaces/security-analyst/AGENTS.md** — Updated context description

## Test plan
- [x] `grep -r 'repo-homelab\|argocd_repo_ssh\|ArgoCD SSH deploy key\|sshPrivateKey.*argocd'` returns zero matches
- [x] `grep -r 'git@github.com:holdennguyen/homelab'` returns zero matches in docs/skills/agents
- [ ] Docs site builds correctly after merge


Made with [Cursor](https://cursor.com)