### PR TITLE
chore: remove remaining Gitea/PostgreSQL references from docs and skills

### DIFF
--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -31,7 +31,6 @@ Run these checks in order and report results:
 
 5. **Service endpoints** — key services reachable:
    ```bash
-   curl -sf http://localhost:30300/api/v1/version   # Gitea
    curl -sf http://localhost:30789/health            # OpenClaw
    ```
 

--- a/.cursor/skills/incident-response/SKILL.md
+++ b/.cursor/skills/incident-response/SKILL.md
@@ -60,7 +60,6 @@ kubectl patch application <app-name> -n argocd \
 kubectl get applications -n argocd
 kubectl get pods -A | grep -v Running | grep -v Completed
 kubectl get externalsecrets -A
-curl -sf http://localhost:30300/api/v1/version   # Gitea
 curl -sf http://localhost:30789/health            # OpenClaw
 ```
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -336,7 +336,6 @@ python scripts/doc-freshness.py --markdown     # Markdown table for PR comments
 ```
   Document                             Status    Doc         Source      Behind
   ───────────────────────────────────  ────────  ──────────  ──────────  ──────────
-  ✓ k8s/apps/gitea/README.md            ok        3cce3e9c    05e88155    —
   ✗ docs/networking.md                   STALE     331be14f    f591ad60    25 commits
 ```
 
@@ -374,7 +373,6 @@ kubectl get pods -A | grep -v Running | grep -v Completed
 kubectl get externalsecrets -A
 
 # 4. Service endpoints reachable
-curl -sf http://localhost:30300/api/v1/version   # Gitea
 curl -sf http://localhost:30400/api/health        # Grafana
 curl -sf http://localhost:30600/api/v3/root/config/  # Authentik
 curl -sf http://localhost:30789/health            # OpenClaw

--- a/k8s/apps/argocd/README.md
+++ b/k8s/apps/argocd/README.md
@@ -27,8 +27,6 @@ flowchart TD
         RootApp -- "watches" --> ArgoDir
         ArgoDir -- "creates" --> ESOApp["Application: external-secrets"]
         ArgoDir -- "creates" --> ESCApp["Application: external-secrets-config"]
-        ArgoDir -- "creates" --> PGApp["Application: postgresql"]
-        ArgoDir -- "creates" --> GiteaApp["Application: gitea"]
         ArgoDir -- "creates" --> MonApp["Application: monitoring"]
         ArgoDir -- "creates" --> AuthApp["Application: authentik"]
         ArgoDir -- "creates" --> OCApp["Application: openclaw"]
@@ -51,8 +49,6 @@ flowchart TD
 | `projects/apps.yaml` | AppProject for user-facing applications |
 | `applications/external-secrets-app.yaml` | ESO Helm chart (sync-wave 0 — installs CRDs first) |
 | `applications/external-secrets-config-app.yaml` | ClusterSecretStore (sync-wave 1 — after ESO CRDs) |
-| `applications/postgresql-app.yaml` | PostgreSQL deployment in `gitea-system` namespace |
-| `applications/gitea-app.yaml` | Gitea deployment in `gitea-system` namespace |
 | `applications/monitoring-app.yaml` | kube-prometheus-stack Helm chart (Grafana + Prometheus) |
 | `applications/monitoring-config-app.yaml` | Grafana ExternalSecret (monitoring namespace) |
 | `applications/authentik-app.yaml` | Authentik SSO Helm chart |
@@ -86,7 +82,6 @@ flowchart LR
     end
 
     subgraph appsProj["apps project"]
-        A4["gitea"]
         A5["monitoring"]
         A6["authentik"]
         A7["openclaw"]
@@ -110,7 +105,7 @@ Sync waves control the order in which resources are applied. AppProjects must ex
 | 0 | `external-secrets` | Installs the ESO Helm chart + CRDs (`ExternalSecret`, `ClusterSecretStore`, etc.) |
 | 1 | `external-secrets-config` | Applies the `ClusterSecretStore` — requires CRDs from wave 0 to be present |
 | 2 | `trivy-operator` | Vulnerability scanner — after core apps are synced |
-| (default) | `postgresql`, `gitea`, `monitoring`, `authentik`, `openclaw`, `namespace-security`, `networking-policies` | No ordering requirements between them |
+| (default) | `monitoring`, `authentik`, `openclaw`, `namespace-security`, `networking-policies` | No ordering requirements between them |
 
 ## ArgoCD Configuration
 
@@ -241,7 +236,7 @@ kubectl get applications -n argocd
 kubectl get pods -n argocd
 
 # Force an immediate sync on a specific application
-kubectl patch application gitea -n argocd \
+kubectl patch application openclaw -n argocd \
   --type merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
 
 # View ArgoCD server logs

--- a/k8s/apps/external-secrets/README.md
+++ b/k8s/apps/external-secrets/README.md
@@ -22,13 +22,19 @@ flowchart TD
         InfisicalAPI["Infisical API\nproject: homelab / env: prod"]
     end
 
-    subgraph giteaNs["gitea-system namespace"]
-        ES1["ExternalSecret: postgresql-secret"]
-        ES2["ExternalSecret: gitea-secret"]
-        ES3["ExternalSecret: gitea-admin-secret"]
-        K8sS1["K8s Secret: postgresql-secret"]
-        K8sS2["K8s Secret: gitea-secret"]
-        K8sS3["K8s Secret: gitea-admin-secret"]
+    subgraph authentikNs["authentik namespace"]
+        ES1["ExternalSecret: authentik-secret"]
+        K8sS1["K8s Secret: authentik-secret"]
+    end
+
+    subgraph monitoringNs["monitoring namespace"]
+        ES2["ExternalSecret: grafana-secret"]
+        K8sS2["K8s Secret: grafana-secret"]
+    end
+
+    subgraph openclawNs["openclaw namespace"]
+        ES3["ExternalSecret: openclaw-secret"]
+        K8sS3["K8s Secret: openclaw-secret"]
     end
 
     ESOApp -- "installs Helm chart\n(includes CRDs)" --> ESOOperator
@@ -129,7 +135,7 @@ flowchart LR
     end
 
     subgraph infisical["Infisical"]
-        Secret["POSTGRES_PASSWORD: abc123"]
+        Secret["MY_API_KEY: abc123"]
     end
 
     ES -- "secretStoreRef:\n  kind: ClusterSecretStore\n  name: infisical" --> CSS
@@ -184,9 +190,6 @@ env:
 
 | ExternalSecret | Namespace | K8s Secret Created | Keys | Consumed By |
 |---|---|---|---|---|
-| `postgresql-secret` | `gitea-system` | `postgresql-secret` | `POSTGRES_PASSWORD`, `POSTGRES_USER`, `POSTGRES_DB`, `GITEA_DB_PASSWORD` | PostgreSQL Deployment env vars; Gitea DB password |
-| `gitea-secret` | `gitea-system` | `gitea-secret` | `GITEA_SECRET_KEY`, `GITEA_OAUTH_CLIENT_SECRET` | Gitea Deployment `GITEA__security__SECRET_KEY`; Gitea OIDC init job |
-| `gitea-admin-secret` | `gitea-system` | `gitea-admin-secret` | `GITEA_ADMIN_USERNAME`, `GITEA_ADMIN_PASSWORD`, `GITEA_ADMIN_EMAIL` | `gitea-admin-init` PostSync Job |
 | `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password` | Authentik server + worker pods; embedded PostgreSQL |
 | `grafana-secret` | `monitoring` | `grafana-secret` | `admin-user`, `admin-password`, `oauth-client-id`, `oauth-client-secret` | Grafana admin login; Grafana OIDC via Authentik |
 | `openclaw-secret` | `openclaw` | `openclaw-secret` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN` | OpenClaw gateway env vars, agent git workflow |
@@ -213,18 +216,18 @@ kubectl describe clustersecretstore infisical
 kubectl get externalsecret -A
 
 # Check specific ExternalSecret
-kubectl describe externalsecret postgresql-secret -n gitea-system
+kubectl describe externalsecret authentik-secret -n authentik
 
 # Force immediate reconciliation (skips refreshInterval)
-kubectl annotate externalsecret postgresql-secret -n gitea-system \
+kubectl annotate externalsecret authentik-secret -n authentik \
   force-sync=$(date +%s) --overwrite
 
 # View the created K8s Secret (base64 encoded)
-kubectl get secret postgresql-secret -n gitea-system -o yaml
+kubectl get secret authentik-secret -n authentik -o yaml
 
 # Decode a specific secret value
-kubectl get secret postgresql-secret -n gitea-system \
-  -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d
+kubectl get secret openclaw-secret -n openclaw \
+  -o jsonpath='{.data.OPENCLAW_GATEWAY_TOKEN}' | base64 -d
 
 # Check ESO operator logs
 kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets --tail=50

--- a/k8s/apps/infisical/README.md
+++ b/k8s/apps/infisical/README.md
@@ -108,21 +108,12 @@ flowchart TD
         subgraph project["Project: homelab\nslug: homelab"]
             subgraph prod["Environment: prod"]
                 subgraph root["Path: /  (root)"]
-                    s1["POSTGRES_PASSWORD"]
-                    s2["POSTGRES_USER"]
-                    s3["POSTGRES_DB"]
-                    s4["GITEA_DB_PASSWORD"]
-                    s5["GITEA_SECRET_KEY"]
-                    s6["GITEA_ADMIN_USERNAME"]
-                    s7["GITEA_ADMIN_PASSWORD"]
-                    s8["GITEA_ADMIN_EMAIL"]
                     s9["AUTHENTIK_SECRET_KEY"]
                     s10["AUTHENTIK_BOOTSTRAP_PASSWORD"]
                     s11["AUTHENTIK_BOOTSTRAP_TOKEN"]
                     s12["AUTHENTIK_POSTGRES_PASSWORD"]
                     s13["GRAFANA_ADMIN_PASSWORD"]
                     s14["GRAFANA_OAUTH_CLIENT_SECRET"]
-                    s15["GITEA_OAUTH_CLIENT_SECRET"]
                     s16["OPENCLAW_GATEWAY_TOKEN"]
                     s17["OPENROUTER_API_KEY"]
                     s17b["GEMINI_API_KEY"]
@@ -138,24 +129,6 @@ flowchart TD
 
 ## Complete Secrets Inventory
 
-### Application Credentials
-
-| Key | Used By | Value Constraints | How to Generate |
-|---|---|---|---|
-| `POSTGRES_PASSWORD` | PostgreSQL Deployment env `POSTGRES_PASSWORD` | Any string, no special char limits | `openssl rand -hex 12` |
-| `POSTGRES_USER` | PostgreSQL Deployment env `POSTGRES_USER` | Static: `gitea` | `gitea` |
-| `POSTGRES_DB` | PostgreSQL Deployment env `POSTGRES_DB` | Static: `gitea` | `gitea` |
-| `GITEA_DB_PASSWORD` | Gitea Deployment env `GITEA__database__PASSWD` | **Must equal `POSTGRES_PASSWORD`** | same as `POSTGRES_PASSWORD` |
-| `GITEA_SECRET_KEY` | Gitea Deployment env `GITEA__security__SECRET_KEY` | Any base64 string | `openssl rand -base64 32` |
-
-### UI Credentials
-
-| Key | Used By | Value Constraints | How to Generate |
-|---|---|---|---|
-| `GITEA_ADMIN_USERNAME` | `gitea-admin-init` PostSync Job | Valid Gitea username | e.g. `holden` |
-| `GITEA_ADMIN_PASSWORD` | `gitea-admin-init` PostSync Job | Any string | `openssl rand -hex 12` |
-| `GITEA_ADMIN_EMAIL` | `gitea-admin-init` PostSync Job | Valid email | your email |
-
 ### SSO & Monitoring Credentials
 
 | Key | Used By | Value Constraints | How to Generate |
@@ -166,8 +139,6 @@ flowchart TD
 | `AUTHENTIK_POSTGRES_PASSWORD` | Authentik ExternalSecret | Authentik internal PostgreSQL | `openssl rand -hex 12` |
 | `GRAFANA_ADMIN_PASSWORD` | Grafana ExternalSecret | Break-glass admin access | `openssl rand -hex 12` |
 | `GRAFANA_OAUTH_CLIENT_SECRET` | Grafana ExternalSecret | OIDC client secret for Authentik | Generated when creating Authentik provider |
-| `GITEA_OAUTH_CLIENT_SECRET` | Gitea ExternalSecret | OIDC client secret for Authentik | Generated when creating Authentik provider |
-
 ### AI Gateway Credentials
 
 | Key | Used By | Value Constraints | How to Generate |
@@ -211,7 +182,6 @@ The slug is hardcoded in `k8s/apps/external-secrets/cluster-secret-store.yaml`. 
 ### Step 3 — Add Secrets
 
 Navigate to `homelab` project → `prod` environment → click the **+** to add secrets. Add every key in the secrets inventory table above. Pay special attention to:
-- `GITEA_DB_PASSWORD` must equal `POSTGRES_PASSWORD` exactly
 - `AUTHENTIK_SECRET_KEY` must never be changed after first install
 
 ### Step 4 — Create Machine Identity

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -106,11 +106,10 @@ flowchart LR
     end
 
     subgraph dataProj["data project"]
-        PG["postgresql"]
+        DataPlaceholder["(reserved)"]
     end
 
     subgraph appsProj["apps project"]
-        Gitea["gitea"]
         Mon["monitoring"]
         OC["openclaw"]
     end

--- a/skills/devops-sre/SKILL.md
+++ b/skills/devops-sre/SKILL.md
@@ -34,7 +34,6 @@ Define and track SLOs for every service. Even in a homelab, SLO thinking enforce
 |---|---|---|---|
 | ArgoCD | Sync success rate | 99% of syncs succeed within 5 min | `kubectl get applications -n argocd` — count `Synced`/total |
 | OpenClaw | Gateway availability | 99% uptime during active hours | Health endpoint `/health` returns 200 |
-| Gitea | HTTP availability | 99% uptime | Health endpoint returns 200 |
 | ESO | Secret sync success | 100% ExternalSecrets in `SecretSynced` | `kubectl get externalsecret -A` |
 | Infisical | API reachability | 99% uptime | Pod health + ESO sync success |
 | PostgreSQL | Pod readiness | 99.5% uptime | StatefulSet ready replicas |
@@ -49,8 +48,7 @@ Every container MUST have resource requests and limits. Follow these guidelines:
 
 | Workload type | CPU request | CPU limit | Memory request | Memory limit |
 |---|---|---|---|---|
-| Lightweight API (Gitea, OpenClaw) | 100m–250m | 1–2 cores | 256Mi–512Mi | 1–2Gi |
-| Database (PostgreSQL) | 250m–500m | 2 cores | 512Mi–1Gi | 2–4Gi |
+| Lightweight API (OpenClaw) | 100m–250m | 1–2 cores | 256Mi–512Mi | 1–2Gi |
 | Cache (Redis) | 100m | 500m | 128Mi | 512Mi |
 | Monitoring (Prometheus) | 250m | 2 cores | 512Mi | 2Gi |
 | Operators (ESO, ArgoCD) | 50m–100m | 500m–1 core | 128Mi–256Mi | 512Mi–1Gi |

--- a/skills/incident-response/SKILL.md
+++ b/skills/incident-response/SKILL.md
@@ -169,8 +169,6 @@ kubectl get pods -A | grep -v Running | grep -v Completed
 kubectl get externalsecrets -A
 
 # 4. Service endpoints reachable (adapt ports to your services)
-# Gitea
-curl -sf http://localhost:30300/api/v1/version
 # Monitoring (Grafana)
 curl -sf http://localhost:30400/api/health
 # Authentik

--- a/skills/qa-tester/SKILL.md
+++ b/skills/qa-tester/SKILL.md
@@ -47,9 +47,7 @@ Focus testing effort based on risk:
 | ArgoCD | High | Critical | Manages all other deployments |
 | ESO + ClusterSecretStore | High | Critical | All secrets depend on it |
 | Infisical | High | Critical | Source of truth for secrets |
-| PostgreSQL | Medium | High | Data persistence, Gitea depends on it |
 | OpenClaw | Medium | High | Agent gateway, multiple components |
-| Gitea | Low | Medium | Independent service |
 | Monitoring | Low | Medium | Observability, non-blocking |
 
 ## Validation commands
@@ -101,22 +99,6 @@ kubectl top pods -A --sort-by=memory
 | Health endpoint | `kubectl exec -n openclaw deploy/openclaw -- wget -qO- http://localhost:18789/health` | 200 |
 | Config mounted | `kubectl exec -n openclaw deploy/openclaw -- cat /config/openclaw.json \| jq '.agents.list \| length'` | Agent count matches config |
 | Skills loaded | `kubectl exec -n openclaw deploy/openclaw -- ls /skills/` | All skill directories present |
-
-### Gitea
-
-| Check | Command | Pass criteria |
-|---|---|---|
-| Pod running | `kubectl get pods -n gitea-system -l app.kubernetes.io/name=gitea` | `Running`, 0 restarts |
-| HTTP health | `curl -sf http://localhost:30300/api/healthz` | 200 |
-| DB connection | `kubectl logs -n gitea-system deploy/gitea --tail=20 \| grep -i "database"` | No errors |
-
-### PostgreSQL
-
-| Check | Command | Pass criteria |
-|---|---|---|
-| Pod running | `kubectl get pods -n gitea-system -l app.kubernetes.io/name=postgresql` | `Running`, 0 restarts |
-| Accepting connections | `kubectl exec -n gitea-system deploy/postgresql -- pg_isready` | accepting connections |
-| PVC bound | `kubectl get pvc -n gitea-system` | `Bound` |
 
 ### Monitoring (Prometheus + Grafana)
 

--- a/skills/secret-management/SKILL.md
+++ b/skills/secret-management/SKILL.md
@@ -64,10 +64,9 @@ kubectl get secret <name> -n <ns> -o jsonpath='{.data.<KEY>}' | base64 -d
 
 | ExternalSecret | Namespace | Keys |
 |---|---|---|
-| `postgresql-secret` | `gitea-system` | POSTGRES_PASSWORD, POSTGRES_USER, POSTGRES_DB, GITEA_DB_PASSWORD |
-| `gitea-secret` | `gitea-system` | GITEA_SECRET_KEY |
-| `gitea-admin-secret` | `gitea-system` | GITEA_ADMIN_USERNAME, GITEA_ADMIN_PASSWORD, GITEA_ADMIN_EMAIL |
-| `openclaw-secret` | `openclaw` | OPENCLAW_GATEWAY_TOKEN, OPENROUTER_API_KEY, GEMINI_API_KEY |
+| `authentik-secret` | `authentik` | AUTHENTIK_SECRET_KEY, AUTHENTIK_BOOTSTRAP_PASSWORD, AUTHENTIK_BOOTSTRAP_TOKEN, AUTHENTIK_POSTGRES_PASSWORD |
+| `grafana-secret` | `monitoring` | GRAFANA_ADMIN_PASSWORD, GRAFANA_OAUTH_CLIENT_SECRET |
+| `openclaw-secret` | `openclaw` | OPENCLAW_GATEWAY_TOKEN, OPENROUTER_API_KEY, GEMINI_API_KEY, GITHUB_TOKEN |
 
 ## Troubleshooting
 

--- a/skills/security-analyst/SKILL.md
+++ b/skills/security-analyst/SKILL.md
@@ -41,7 +41,7 @@ Apply STRIDE for every new service or significant configuration change:
 
 | Threat | Question to ask | Homelab mitigations |
 |---|---|---|
-| **Spoofing** | Can an attacker impersonate a user or service? | Tailscale identity (WireGuard), OPENCLAW_GATEWAY_TOKEN, Gitea auth |
+| **Spoofing** | Can an attacker impersonate a user or service? | Tailscale identity (WireGuard), OPENCLAW_GATEWAY_TOKEN, Authentik SSO |
 | **Tampering** | Can data in transit or at rest be modified? | WireGuard encryption (Tailscale), ArgoCD selfHeal reverts unauthorized changes |
 | **Repudiation** | Can actions be performed without accountability? | Agent footprint (git identity, labeled issues/PRs), pod audit logs |
 | **Information Disclosure** | Can secrets or data leak? | Secrets in Infisical (never git), ESO sync, Tailscale-only access |
@@ -135,8 +135,6 @@ Rule: NodePort services are accessible only on localhost. External access is exc
 | OpenClaw | `openclaw:latest` | Built locally from submodule + `Dockerfile.openclaw` | Yes (source in repo) |
 | ArgoCD | Official Helm chart images | `quay.io/argoproj/argocd` | Yes (upstream) |
 | ESO | Official Helm chart images | `ghcr.io/external-secrets/external-secrets` | Yes (upstream) |
-| Gitea | `gitea/gitea` | Docker Hub official | Yes (upstream) |
-| PostgreSQL | `postgres` | Docker Hub official | Yes (upstream) |
 | Prometheus/Grafana | kube-prometheus-stack images | Upstream Helm chart | Yes (upstream) |
 
 Flag any image that doesn't come from an official or verified source.


### PR DESCRIPTION
## Summary

- Follow-up to #63 — removes all remaining Gitea and PostgreSQL references that were missed in the initial decommission PR
- Cleans 12 files across ArgoCD README, ESO README, Infisical README, OpenClaw README, 5 agent skill files, Cursor incident-response skill, Cursor verifier agent, and git-workflow docs
- Updates ESO architecture diagram to reflect actual current ExternalSecrets (authentik, grafana, openclaw)
- Replaces generic placeholder example from `POSTGRES_PASSWORD` to `MY_API_KEY`

## Files changed

| File | Change |
|---|---|
| `k8s/apps/argocd/README.md` | Remove Gitea/PostgreSQL from app diagram, file table, sync wave table, force-sync example |
| `k8s/apps/external-secrets/README.md` | Replace gitea-system diagram with actual namespaces, remove gitea ExternalSecret rows, update operational commands |
| `k8s/apps/infisical/README.md` | Remove POSTGRES_*/GITEA_* from secret diagram and inventory tables |
| `k8s/apps/openclaw/README.md` | Remove gitea/postgresql from ArgoCD project diagram |
| `skills/security-analyst/SKILL.md` | Remove Gitea auth from STRIDE table, remove Gitea/PostgreSQL from image provenance |
| `skills/qa-tester/SKILL.md` | Remove Gitea/PostgreSQL from dependency table and health check sections |
| `skills/devops-sre/SKILL.md` | Remove Gitea SLO, update resource sizing table |
| `skills/incident-response/SKILL.md` | Remove Gitea health check curl |
| `skills/secret-management/SKILL.md` | Replace gitea-system secrets with actual current ExternalSecrets |
| `.cursor/skills/incident-response/SKILL.md` | Remove Gitea health check curl |
| `.cursor/agents/verifier.md` | Remove Gitea health check curl |
| `docs/git-workflow.md` | Remove Gitea from doc-manifest example and health check commands |

## Test plan

- [ ] `grep -ri gitea` returns zero results (excluding `.git/`)
- [ ] MkDocs builds without errors
- [ ] No ArgoCD sync regressions after merge


Made with [Cursor](https://cursor.com)