### PR TITLE
fix: remove tenant from blueprint as it is not allowed in this context

### DIFF
--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -7,13 +7,6 @@ data:
   bookmarks.yaml: |
     version: 1
     entries:
-      - model: authentik_tenants.tenant
-        id: tenant-default
-        state: present
-        identifiers:
-          domain: authentik-default
-        attrs:
-          branding_title: Homelab Portal
       - model: authentik_core.application
         id: app-infisical
         state: present


### PR DESCRIPTION
Removing the tenant config from the blueprint as it fails validation in the worker pod.

Made with [Cursor](https://cursor.com)