### PR TITLE
fix: use identifiers block for slug in authentik blueprint

### DIFF
--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -135,9 +135,10 @@ For services without native OIDC support, you can add them to the Authentik port
       - model: authentik_core.application
         id: app-my-service
         state: present
+        identifiers:
+          slug: my-service
         attrs:
           name: My Service
-          slug: my-service
           group: Development # Or whatever logical group makes sense
           meta_launch_url: https://url-to-service
           meta_icon: https://url-to-icon.png

--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -10,9 +10,10 @@ data:
       - model: authentik_core.application
         id: app-infisical
         state: present
+        identifiers:
+          slug: infisical
         attrs:
           name: Infisical
-          slug: infisical
           group: Infrastructure
           meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8445
           meta_icon: https://raw.githubusercontent.com/Infisical/infisical/main/docs/static/img/logo-dark.png
@@ -21,9 +22,10 @@ data:
       - model: authentik_core.application
         id: app-mkdocs
         state: present
+        identifiers:
+          slug: mkdocs
         attrs:
           name: Homelab Docs
-          slug: mkdocs
           group: Documentation
           meta_launch_url: https://holdennguyen.github.io/homelab
           meta_icon: https://squidfunk.github.io/mkdocs-material/assets/logo.png
@@ -32,9 +34,10 @@ data:
       - model: authentik_core.application
         id: app-trivy
         state: present
+        identifiers:
+          slug: trivy
         attrs:
           name: Trivy Operator
-          slug: trivy
           group: Security
           meta_launch_url: ""
           meta_icon: https://raw.githubusercontent.com/aquasecurity/trivy/main/docs/docs/imgs/logo.png


### PR DESCRIPTION
The previous blueprint failed validation because the `slug` was placed under `attrs` instead of `identifiers`. This corrects the YAML structure so the blueprint is applied successfully.

Made with [Cursor](https://cursor.com)