### PR TITLE
feat: deploy Trivy Operator Dashboard with Authentik portal bookmark

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -29,6 +29,7 @@ flowchart TD
             TLS443["HTTPS :443\nAuthentik (SSO portal)"]
             TLS8443["HTTPS :8443\nArgoCD"]
             TLS8444["HTTPS :8444\nGrafana"]
+            TLS8448
         end
 
         subgraph orbstack["OrbStack Kubernetes"]
@@ -44,12 +45,16 @@ flowchart TD
             subgraph infisicalNs["infisical namespace"]
                 InfisicalSvc["infisical\nNodePort 30445"]
             end
+            subgraph trivyDashNs["trivy-dashboard namespace"]
+                TrivyDashSvc["trivy-dashboard\nNodePort 30448"]
+            end
         end
 
         TLS443 -- "http://localhost:30500" --> AuthentikSvc
         TLS8443 -- "http://localhost:30080" --> ArgoCDSvc
         TLS8444 -- "http://localhost:30090" --> GrafanaSvc
-        TLS8445["HTTPS :8445"] -- "http://localhost:30445" --> InfisicalSvc
+            TLS8445["HTTPS :8445"] -- "http://localhost:30445" --> InfisicalSvc
+            TLS8448["HTTPS :8448"] -- "http://localhost:30448" --> TrivyDashSvc
     end
 
     iPhone -- "https://holdens-mac-mini\n.story-larch.ts.net" --> TLS443
@@ -100,6 +105,7 @@ sequenceDiagram
 | ArgoCD HTTP | 8080 | 30080 | `http://localhost:30080` |
 | Grafana | 3000 | 30090 | `http://localhost:30090` |
 | Infisical | 8080 | 30445 | `http://localhost:30445` |
+| Trivy Dashboard | 8900 | 30448 | `http://localhost:30448` |
 | OpenClaw | 18789 | 30789 | `http://localhost:30789` |
 
 ## Layer 2: Tailscale Serve
@@ -120,6 +126,9 @@ tailscale serve --bg --https 8444 http://localhost:30090
 
 # Infisical — custom HTTPS port (8445)
 tailscale serve --bg --https 8445 http://localhost:30445
+
+# Trivy Dashboard — custom HTTPS port (8448)
+tailscale serve --bg --https 8448 http://localhost:30448
 
 # OpenClaw — custom HTTPS port (8447)
 tailscale serve --bg --https 8447 http://localhost:30789
@@ -174,6 +183,9 @@ https://holdens-mac-mini.story-larch.ts.net:8445 (tailnet only)
 
 https://holdens-mac-mini.story-larch.ts.net:8447 (tailnet only)
 |-- / proxy http://localhost:30789
+
+https://holdens-mac-mini.story-larch.ts.net:8448 (tailnet only)
+|-- / proxy http://localhost:30448
 ```
 
 ### Manage Serve
@@ -187,6 +199,9 @@ tailscale serve --https=8443 off
 
 # Stop Grafana proxy
 tailscale serve --https=8444 off
+
+# Stop Trivy Dashboard proxy
+tailscale serve --https=8448 off
 
 # Stop OpenClaw proxy
 tailscale serve --https=8447 off
@@ -216,6 +231,7 @@ Tailscale's MagicDNS automatically resolves `<hostname>.story-larch.ts.net` to t
 | Grafana | `https://holdens-mac-mini.story-larch.ts.net:8444` | 8444 | SSO via Authentik |
 | Infisical | `https://holdens-mac-mini.story-larch.ts.net:8445` | 8445 | Local admin |
 | Gitea | `https://holdens-mac-mini.story-larch.ts.net:8446` | 8446 | SSO via Authentik |
+| Trivy Dashboard | `https://holdens-mac-mini.story-larch.ts.net:8448` | 8448 | SSO portal bookmark |
 | OpenClaw | `https://holdens-mac-mini.story-larch.ts.net:8447` | 8447 | Local |
 
 ### Tailscale Serve vs Funnel
@@ -249,7 +265,7 @@ flowchart TD
 
     subgraph tailnet["Tailscale Tailnet (story-larch)"]
         subgraph mac["Mac mini M4\n100.77.144.4"]
-            TS["tailscale serve\n:443, :8443, :8444, :8445, :8447"]
+            TS["tailscale serve\n:443, :8443, :8444, :8445, :8447, :8448"]
 
             subgraph orb["OrbStack Kubernetes"]
                 subgraph authentik["authentik ns"]
@@ -265,6 +281,9 @@ flowchart TD
                 subgraph infisical_ns["infisical ns"]
                     InfisicalSvc2["infisical\nNodePort 30445"]
                 end
+                subgraph trivydash_ns["trivy-dashboard ns"]
+                    TrivyDashSvc2["trivy-dashboard\nNodePort 30448"]
+                end
                 subgraph openclaw_ns["openclaw ns"]
                     OpenClawSvc["openclaw\nNodePort 30789"]
                 end
@@ -274,6 +293,7 @@ flowchart TD
             TS -- "localhost:30080" --> ArgoSvc
             TS -- "localhost:30090" --> GrafanaSvc2
             TS -- "localhost:30445" --> InfisicalSvc2
+            TS -- "localhost:30448" --> TrivyDashSvc2
             TS -- "localhost:30789" --> OpenClawSvc
             ArgoCtrl -- "poll" --> GitHub
             LetsEncrypt -. "auto cert" .-> TS

--- a/k8s/apps/argocd/README.md
+++ b/k8s/apps/argocd/README.md
@@ -32,6 +32,7 @@ flowchart TD
         ArgoDir -- "creates" --> OCApp["Application: openclaw"]
         ArgoDir -- "creates" --> TrivyApp["Application: trivy-operator"]
         ArgoDir -- "creates" --> TrivyScannerApp["Application: trivy-operator-vulnerability-scanner"]
+        ArgoDir -- "creates" --> TrivyDashApp["Application: trivy-dashboard"]
         ArgoDir -- "creates" --> NSApp["Application: namespace-security"]
         ArgoDir -- "creates" --> NPApp["Application: networking-policies"]
     end
@@ -55,6 +56,7 @@ flowchart TD
 | `applications/authentik-config-app.yaml` | Authentik ExternalSecret (authentik namespace) |
 | `applications/openclaw-app.yaml` | OpenClaw AI gateway deployment |
 | `applications/trivy-operator-app.yaml` | Trivy vulnerability scanner Helm chart (monitoring namespace, ClientServer mode) |
+| `applications/trivy-dashboard-app.yaml` | Trivy Operator Dashboard web UI (trivy-dashboard namespace) |
 | `applications/trivy-operator-vulnerability-scanner-app.yaml` | Trivy VulnerabilityScanner CR for scheduled daily scans |
 | `applications/namespace-security-app.yaml` | Pod Security Standard labels for namespaces |
 | `applications/networking-policies-app.yaml` | Default-deny NetworkPolicies across all namespaces |
@@ -86,6 +88,7 @@ flowchart LR
         A6["authentik"]
         A7["openclaw"]
         A8["trivy-operator"]
+        A11["trivy-dashboard"]
         A9["namespace-security"]
         A10["networking-policies"]
     end

--- a/k8s/apps/argocd/applications/trivy-dashboard-app.yaml
+++ b/k8s/apps/argocd/applications/trivy-dashboard-app.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trivy-dashboard
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: trivy-dashboard
+    app.kubernetes.io/part-of: homelab
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/managed-by: argocd
+spec:
+  project: apps
+  source:
+    repoURL: https://github.com/holdennguyen/homelab.git
+    targetRevision: HEAD
+    path: k8s/apps/trivy-dashboard
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: trivy-dashboard
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/apps/argocd/kustomization.yaml
+++ b/k8s/apps/argocd/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - applications/networking-policies-app.yaml
   - applications/namespace-security-app.yaml
   - applications/trivy-operator-app.yaml
+  - applications/trivy-dashboard-app.yaml

--- a/k8s/apps/argocd/projects/apps.yaml
+++ b/k8s/apps/argocd/projects/apps.yaml
@@ -21,6 +21,8 @@ spec:
       namespace: openclaw
     - server: https://kubernetes.default.svc
       namespace: authentik
+    - server: https://kubernetes.default.svc
+      namespace: trivy-dashboard
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -121,7 +121,7 @@ tailscale serve --bg http://localhost:30500
 | ArgoCD | `oidc.config` | `https://holdens-mac-mini.story-larch.ts.net:8443` |
 | Gitea | OAuth2 source | `https://holdens-mac-mini.story-larch.ts.net:8446` |
 | Infisical | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8445` |
-| Trivy Operator | Bookmark | (No web UI) |
+| Trivy Dashboard | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8448` |
 | Homelab Docs | Bookmark | `https://holdennguyen.github.io/homelab` |
 
 ## Adding a new Bookmark Application

--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -37,9 +37,9 @@ data:
         identifiers:
           slug: trivy
         attrs:
-          name: Trivy Operator
+          name: Trivy Dashboard
           group: Security
-          meta_launch_url: ""
+          meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8448
           meta_icon: https://raw.githubusercontent.com/aquasecurity/trivy/main/docs/docs/imgs/logo.png
-          meta_description: Cluster Vulnerability Scanning
+          meta_description: Trivy Operator Security Dashboard
           meta_publisher: Homelab

--- a/k8s/apps/trivy-dashboard/README.md
+++ b/k8s/apps/trivy-dashboard/README.md
@@ -1,0 +1,67 @@
+# Trivy Dashboard
+
+Web UI for browsing [Trivy Operator](https://github.com/aquasecurity/trivy-operator) security reports. Based on [raoulx24/trivy-operator-dashboard](https://github.com/raoulx24/trivy-operator-dashboard).
+
+## Access
+
+| Interface | URL |
+|---|---|
+| Tailscale | `https://holdens-mac-mini.story-larch.ts.net:8448` |
+| Local | `http://localhost:30448` |
+
+One-time Tailscale Serve setup:
+
+```bash
+tailscale serve --bg --https 8448 http://localhost:30448
+```
+
+## Architecture
+
+The dashboard reads Trivy CRDs (VulnerabilityReports, ConfigAuditReports, etc.) from the Kubernetes API via a read-only ClusterRole. It has no database or persistent state.
+
+```mermaid
+flowchart LR
+    subgraph trivyDash["trivy-dashboard namespace"]
+        Dashboard["trivy-dashboard\n:8900 → NodePort 30448"]
+    end
+
+    subgraph monitoring["monitoring namespace"]
+        TrivyOp["trivy-operator"]
+    end
+
+    K8sAPI["Kubernetes API"]
+
+    TrivyOp -- "creates CRDs" --> K8sAPI
+    Dashboard -- "reads CRDs\n(ClusterRole)" --> K8sAPI
+```
+
+## Directory Contents
+
+| File | Purpose |
+|------|---------|
+| `kustomization.yaml` | Lists all resources for Kustomize/ArgoCD rendering |
+| `deployment.yaml` | Trivy Dashboard Deployment (image `ghcr.io/raoulx24/trivy-operator-dashboard:1.8.0`) |
+| `service.yaml` | NodePort Service on port 30448 |
+| `serviceaccount.yaml` | ServiceAccount for API access |
+| `clusterrole.yaml` | Read-only access to all Trivy CRDs and namespaces |
+| `clusterrolebinding.yaml` | Binds ClusterRole to the ServiceAccount |
+| `networkpolicy.yaml` | Default-deny with allowances for Tailscale ingress, DNS, and API server |
+
+## Networking
+
+| Layer | Value |
+|---|---|
+| Container port | 8900 |
+| NodePort | 30448 |
+| Tailscale HTTPS | 8448 |
+| URL | `https://holdens-mac-mini.story-larch.ts.net:8448` |
+
+## Updating
+
+To upgrade the dashboard image, update the tag in `deployment.yaml`:
+
+```yaml
+image: ghcr.io/raoulx24/trivy-operator-dashboard:<new-version>
+```
+
+Check releases at https://github.com/raoulx24/trivy-operator-dashboard/releases.

--- a/k8s/apps/trivy-dashboard/clusterrole.yaml
+++ b/k8s/apps/trivy-dashboard/clusterrole.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: trivy-dashboard
+  labels:
+    app.kubernetes.io/name: trivy-dashboard
+    app.kubernetes.io/part-of: trivy-operator
+    app.kubernetes.io/component: web
+rules:
+  - apiGroups: ["aquasecurity.github.io"]
+    resources:
+      - clustercompliancereports
+      - clusterinfraassessmentreports
+      - clusterrbacassessmentreports
+      - clustersbomreports
+      - clustervulnerabilityreports
+      - configauditreports
+      - exposedsecretreports
+      - infraassessmentreports
+      - rbacassessmentreports
+      - sbomreports
+      - vulnerabilityreports
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]

--- a/k8s/apps/trivy-dashboard/clusterrolebinding.yaml
+++ b/k8s/apps/trivy-dashboard/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: trivy-dashboard
+  labels:
+    app.kubernetes.io/name: trivy-dashboard
+    app.kubernetes.io/part-of: trivy-operator
+    app.kubernetes.io/component: web
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trivy-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: trivy-dashboard
+    namespace: trivy-dashboard

--- a/k8s/apps/trivy-dashboard/deployment.yaml
+++ b/k8s/apps/trivy-dashboard/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trivy-dashboard
+  namespace: trivy-dashboard
+  labels:
+    app.kubernetes.io/name: trivy-dashboard
+    app.kubernetes.io/part-of: trivy-operator
+    app.kubernetes.io/component: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trivy-dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trivy-dashboard
+        app.kubernetes.io/part-of: trivy-operator
+        app.kubernetes.io/component: web
+    spec:
+      serviceAccountName: trivy-dashboard
+      containers:
+        - name: trivy-dashboard
+          image: ghcr.io/raoulx24/trivy-operator-dashboard:1.8.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MAINAPPPORT
+              value: "8900"
+            - name: KUBERNETES__USEDEFAULTCONTEXT
+              value: "true"
+            - name: KUBERNETES__NAMESPACELIST
+              value: ""
+            - name: KUBERNETES__TRIVYUSECLUSTERCOMPLIANCEREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSECLUSTERINFRAASSESSMENTREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSECLUSTERRBACASSESSMENTREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSECLUSTERSBOMREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSECLUSTERVULNERABILITYREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSECONFIGAUDITREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSEINFRAASSESSMENTREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSEEXPOSEDSECRETREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSERBACASSESSMENTREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSESBOMREPORT
+              value: "true"
+            - name: KUBERNETES__TRIVYUSEVULNERABILITYREPORT
+              value: "true"
+            - name: FILEREPOSITORY__BASEPATH
+              value: ""
+            - name: GITHUB__SERVERCHECKFORUPDATES
+              value: "true"
+            - name: GITHUB__CHECKFORUPDATESINTERVALINMINUTES
+              value: "360"
+            - name: OPENTELEMETRY__ENABLED
+              value: "false"
+            - name: SERILOG__MINIMUMLEVEL__DEFAULT
+              value: Information
+          ports:
+            - name: http
+              containerPort: 8900
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz/ready
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /healthz/live
+              port: http
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: http
+            periodSeconds: 30
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-volume
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 384Mi
+      volumes:
+        - name: tmp-volume
+          emptyDir:
+            sizeLimit: 1024Mi

--- a/k8s/apps/trivy-dashboard/kustomization.yaml
+++ b/k8s/apps/trivy-dashboard/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml

--- a/k8s/apps/trivy-dashboard/networkpolicy.yaml
+++ b/k8s/apps/trivy-dashboard/networkpolicy.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: trivy-dashboard
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: trivy-dashboard
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector: {}
+  egress:
+  - to:
+    - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: trivy-dashboard
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-tailscale-ingress
+  namespace: trivy-dashboard
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 100.64.0.0/10
+    ports:
+    - protocol: TCP
+      port: 8900
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-apiserver
+  namespace: trivy-dashboard
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: TCP
+      port: 6443

--- a/k8s/apps/trivy-dashboard/service.yaml
+++ b/k8s/apps/trivy-dashboard/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trivy-dashboard
+  namespace: trivy-dashboard
+  labels:
+    app.kubernetes.io/name: trivy-dashboard
+    app.kubernetes.io/part-of: trivy-operator
+    app.kubernetes.io/component: web
+spec:
+  type: NodePort
+  ports:
+    - port: 8900
+      targetPort: http
+      nodePort: 30448
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: trivy-dashboard

--- a/k8s/apps/trivy-dashboard/serviceaccount.yaml
+++ b/k8s/apps/trivy-dashboard/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trivy-dashboard
+  namespace: trivy-dashboard
+  labels:
+    app.kubernetes.io/name: trivy-dashboard
+    app.kubernetes.io/part-of: trivy-operator
+    app.kubernetes.io/component: web


### PR DESCRIPTION
## Summary

- Deploys [Trivy Operator Dashboard](https://github.com/raoulx24/trivy-operator-dashboard) v1.8.0 as a Kustomize-managed application in the `trivy-dashboard` namespace
- Exposes the dashboard via NodePort 30448 / Tailscale Serve HTTPS :8448
- Updates the Authentik blueprint to change the Trivy bookmark from a placeholder (no UI) to the live dashboard URL
- Includes full NetworkPolicy set (default-deny, Tailscale ingress, DNS, API server egress)
- Updates `docs/networking.md`, ArgoCD README, and Authentik README with the new service

## New files

- `k8s/apps/trivy-dashboard/` — Deployment, Service, ServiceAccount, ClusterRole, ClusterRoleBinding, NetworkPolicy
- `k8s/apps/argocd/applications/trivy-dashboard-app.yaml` — ArgoCD Application CR

## Post-merge steps

1. Wait for ArgoCD sync (~3 min) or force refresh
2. Run `tailscale serve --bg --https 8448 http://localhost:30448` on the Mac mini
3. Verify at `https://holdens-mac-mini.story-larch.ts.net:8448`


Made with [Cursor](https://cursor.com)