### PR TITLE
docs: pre-release v1.2.0 documentation freshness sweep

### DIFF
--- a/.doc-manifest.yml
+++ b/.doc-manifest.yml
@@ -52,6 +52,10 @@ documents:
     sources:
       - k8s/apps/trivy-operator/
 
+  - doc: k8s/apps/trivy-dashboard/README.md
+    sources:
+      - k8s/apps/trivy-dashboard/
+
   - doc: terraform/README.md
     sources:
       - terraform/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ flowchart TD
         subgraph openclawNs["openclaw namespace"]
             OpenClawPod["OpenClaw Gateway\nNodePort :30789"]
         end
+
+        subgraph trivyDashNs["trivy-dashboard namespace"]
+            TrivyDash["Trivy Dashboard\nNodePort :30448"]
+        end
     end
 
     TF -- "Helm release" --> ArgoCD
@@ -59,6 +63,7 @@ flowchart TD
     ArgoCD -- "App of Apps" --> authentikNs
     ArgoCD -- "App of Apps" --> monNs
     ArgoCD -- "App of Apps" --> openclawNs
+    ArgoCD -- "App of Apps" --> trivyDashNs
     ArgoCD -- "manages" --> NsPolicies
     ArgoCD -- "manages" --> NetPolicies
     TrivyOp -->|watches pods| monNs
@@ -72,6 +77,7 @@ flowchart TD
     TServe -- ":8444 -> :30090" --> GrafanaPod
     TServe -- ":8445 -> :30445" --> InfisicalSvc
     TServe -- ":8447 -> :30789" --> OpenClawPod
+    TServe -- ":8448 -> :30448" --> TrivyDash
 ```
 
 ## Repository Structure
@@ -102,11 +108,12 @@ homelab/
 │       ├── namespace-security/    # Pod Security Standard labels per namespace
 │       ├── networking-policies/   # Default-deny NetworkPolicy per namespace
 │       ├── openclaw/              # OpenClaw AI gateway kustomize manifests
-│       └── trivy-operator/        # Container image vulnerability scanning
+│       ├── trivy-operator/        # Container image vulnerability scanning
+│       └── trivy-dashboard/       # Trivy Operator Dashboard web UI
 ├── docs/                          # MkDocs documentation site
 ├── agents/                        # OpenClaw agent definitions
 │   └── workspaces/                # Per-agent AGENTS.md personality files (5 agents)
-├── skills/                        # OpenClaw homelab-specific skills (9 domains)
+├── skills/                        # OpenClaw homelab-specific skills (8 domains)
 ├── openclaw/                      # OpenClaw source (git submodule)
 └── scripts/                       # Helper scripts (image builds, etc.)
 ```
@@ -143,6 +150,7 @@ sequenceDiagram
 | External Secrets Operator | Helm chart via ArgoCD | `external-secrets` | internal only |
 | Grafana + Prometheus | Helm chart via ArgoCD | `monitoring` | `https://holdens-mac-mini.story-larch.ts.net:8444` |
 | Trivy Operator | Helm chart via ArgoCD | `monitoring` | internal only (CRs: `kubectl get vulnerabilityreports -A`) |
+| Trivy Dashboard | Kustomize via ArgoCD | `trivy-dashboard` | `https://holdens-mac-mini.story-larch.ts.net:8448` |
 | OpenClaw | Kustomize via ArgoCD | `openclaw` | `https://holdens-mac-mini.story-larch.ts.net:8447` |
 | Namespace Security | Kustomize via ArgoCD | `argocd` | cluster-wide Pod Security Standard labels |
 | Network Policies | Kustomize via ArgoCD | `argocd` | default-deny ingress/egress per namespace |
@@ -193,6 +201,7 @@ Once ArgoCD deploys Infisical (check: `kubectl get pods -n infisical`), open the
 | `OPENCLAW_GATEWAY_TOKEN` | Random hex string (`openssl rand -hex 32`) |
 | `OPENROUTER_API_KEY` | OpenRouter API key from [openrouter.ai/keys](https://openrouter.ai/keys) |
 | `GEMINI_API_KEY` | Google Gemini API key from [aistudio.google.com/apikey](https://aistudio.google.com/apikey) |
+| `GITHUB_TOKEN` | GitHub personal access token for OpenClaw agent git operations |
 
 Then create a Machine Identity in Infisical (`Settings → Machine Identities → Universal Auth`), grant it **Member** access to the `homelab` project, update `terraform/terraform.tfvars` with the new `clientId` / `clientSecret`, and re-run `terraform apply` to update the credential. See [docs/bootstrap.md](docs/bootstrap.md) for the full step-by-step.
 
@@ -206,6 +215,7 @@ tailscale serve --bg --https 8443 http://localhost:30080          # ArgoCD
 tailscale serve --bg --https 8444 http://localhost:30090          # Grafana
 tailscale serve --bg --https 8445 http://localhost:30445          # Infisical
 tailscale serve --bg --https 8447 http://localhost:30789          # OpenClaw
+tailscale serve --bg --https 8448 http://localhost:30448          # Trivy Dashboard
 
 tailscale serve status
 ```
@@ -217,6 +227,7 @@ Access URLs (any Tailscale device):
 - Grafana: `https://holdens-mac-mini.story-larch.ts.net:8444`
 - Infisical: `https://holdens-mac-mini.story-larch.ts.net:8445`
 - OpenClaw: `https://holdens-mac-mini.story-larch.ts.net:8447`
+- Trivy Dashboard: `https://holdens-mac-mini.story-larch.ts.net:8448`
 
 ### Verify Deployment
 
@@ -254,6 +265,7 @@ kubectl get pods -A | grep -v Running | grep -v Completed
 | [k8s/apps/monitoring/README.md](k8s/apps/monitoring/README.md) | Grafana + Prometheus monitoring stack, ExternalSecret, SSO integration |
 | [k8s/apps/openclaw/README.md](k8s/apps/openclaw/README.md) | OpenClaw AI gateway deployment, configuration, image builds |
 | [k8s/apps/trivy-operator/README.md](k8s/apps/trivy-operator/README.md) | Container image vulnerability scanning, ClientServer mode, Helm values |
+| [k8s/apps/trivy-dashboard/README.md](k8s/apps/trivy-dashboard/README.md) | Trivy Operator Dashboard web UI, vulnerability report viewer |
 
 ## Documentation Freshness Tracking
 
@@ -279,3 +291,5 @@ When adding a new service or documentation file, add an entry to `.doc-manifest.
 4. **Logging** -- Loki for centralized log aggregation
 
 > **Completed in v1.1.0:** Security hardening — network policies (default-deny per namespace), Pod Security Standards enforcement, RBAC scope-down (OpenClaw cluster-admin removed), non-root execution for all services, and container image vulnerability scanning (Trivy Operator).
+
+> **Completed in v1.2.0:** Infrastructure optimization & observability — automated nightly shutdown/startup, monitoring dashboards and alerting rules as code, Gitea/PostgreSQL decommissioned (GitHub adopted), Authentik app portal with bookmarks, Trivy Dashboard, agent skills optimization.

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -341,7 +341,7 @@ Skills provide domain-specific knowledge and commands to agents. They live in `s
 | `devops-sre` | Infrastructure debugging, Terraform, incident response, SLOs, deployment strategies |
 | `software-engineer` | Code development, review, testing, K8s manifest conventions, dependency management |
 | `security-analyst` | Security audits, RBAC review, vulnerability assessment, STRIDE threat modeling, CIS hardening |
-| `qa-tester` | Deployment validation, service health testing, regression checks, per-service acceptance criteria |
+| `qa-tester` | Deployment validation, service health testing, regression checks, per-service acceptance criteria (ArgoCD, ESO, Infisical, OpenClaw, Monitoring, Authentik) |
 | `gitops` | ArgoCD App of Apps pattern, sync management, mandatory git workflow reference |
 | `incident-response` | Incident triage, rollback procedures, pre-merge validation, post-incident documentation |
 | `secret-management` | Infisical → ESO → K8s pipeline operations |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ Applications are organized into three **AppProjects** that scope which repos, na
 |---|---|---|
 | `secrets` | Secret management infrastructure | `infisical`, `external-secrets`, `external-secrets-config` |
 | `data` | Databases and data stores | (reserved for future use) |
-| `apps` | User-facing applications | `monitoring`, `authentik`, `openclaw`, `trivy-operator`, `trivy-operator-vulnerability-scanner`, `namespace-security`, `networking-policies` |
+| `apps` | User-facing applications | `monitoring`, `authentik`, `openclaw`, `trivy-operator`, `trivy-operator-vulnerability-scanner`, `trivy-dashboard`, `namespace-security`, `networking-policies` |
 | `default` | Bootstrap only | `argocd-apps` (root) |
 
 ```mermaid
@@ -96,6 +96,7 @@ flowchart LR
             AuthApp["authentik"]
             OCApp["openclaw"]
             TrivyApp["trivy-operator"]
+            TrivyDashApp["trivy-dashboard"]
             NSApp["namespace-security"]
             NPApp["networking-policies"]
         end
@@ -207,6 +208,10 @@ flowchart TD
         OpenClawPod["OpenClaw Gateway\nNodePort :30789"]
     end
 
+    subgraph trivyDashNs["trivy-dashboard namespace"]
+        TrivyDashPod["Trivy Dashboard\nNodePort :30448"]
+    end
+
     AuthentikPod -. "OIDC" .-> GrafanaPod
     AuthentikPod -. "OIDC" .-> ArgoServer
     ESOPod --> CSS
@@ -228,6 +233,7 @@ Services are exposed through **Tailscale Serve**, which provides automatic TLS c
 | Grafana | `:30090` | `https://holdens-mac-mini.story-larch.ts.net:8444` | 8444 | SSO via Authentik |
 | Infisical | `:30445` | `https://holdens-mac-mini.story-larch.ts.net:8445` | 8445 | Local admin |
 | OpenClaw | `:30789` | `https://holdens-mac-mini.story-larch.ts.net:8447` | 8447 | Local |
+| Trivy Dashboard | `:30448` | `https://holdens-mac-mini.story-larch.ts.net:8448` | 8448 | Bookmark via Authentik |
 
 For the full networking reference, see [docs/networking.md](./networking.md).
 
@@ -272,6 +278,7 @@ homelab/
 │       ├── monitoring/             # Grafana ExternalSecret
 │       ├── openclaw/               # OpenClaw AI gateway manifests
 │       ├── trivy-operator/         # Trivy vulnerability scanner (README only; deployed via Helm)
+│       ├── trivy-dashboard/       # Trivy Operator Dashboard web UI
 │       ├── namespace-security/     # Pod Security Standard labels for namespaces
 │       └── networking-policies/    # Default-deny NetworkPolicies for all namespaces
 ├── docs/                           # MkDocs documentation site

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -225,6 +225,9 @@ tailscale serve --bg --https 8445 http://localhost:30445
 
 # OpenClaw — custom HTTPS port 8447
 tailscale serve --bg --https 8447 http://localhost:30789
+
+# Trivy Dashboard — custom HTTPS port 8448
+tailscale serve --bg --https 8448 http://localhost:30448
 ```
 
 Verify:
@@ -250,6 +253,9 @@ https://holdens-mac-mini.story-larch.ts.net:8445 (tailnet only)
 
 https://holdens-mac-mini.story-larch.ts.net:8447 (tailnet only)
 |-- / proxy http://localhost:30789
+
+https://holdens-mac-mini.story-larch.ts.net:8448 (tailnet only)
+|-- / proxy http://localhost:30448
 ```
 
 ## Step 7: Verify Everything is Healthy
@@ -277,6 +283,7 @@ Access URLs after bootstrap:
 | Grafana | `https://holdens-mac-mini.story-larch.ts.net:8444` | SSO via Authentik |
 | Infisical | `https://holdens-mac-mini.story-larch.ts.net:8445` | Local admin |
 | OpenClaw | `https://holdens-mac-mini.story-larch.ts.net:8447` | Local |
+| Trivy Dashboard | `https://holdens-mac-mini.story-larch.ts.net:8448` | Bookmark via Authentik |
 
 ## Re-bootstrap from Scratch
 

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -97,7 +97,8 @@ flowchart LR
                         s14["GRAFANA_OAUTH_CLIENT_SECRET"]
                         s16["OPENCLAW_GATEWAY_TOKEN"]
                         s17["OPENROUTER_API_KEY"]
-                        s18["GITHUB_TOKEN"]
+                        s18["GEMINI_API_KEY"]
+                        s19["GITHUB_TOKEN"]
                     end
                 end
             end
@@ -117,7 +118,7 @@ The ClusterSecretStore in `k8s/apps/external-secrets/cluster-secret-store.yaml` 
 - `environmentSlug: prod`
 - `secretsPath: /`
 
-This means any `ExternalSecret` using this store references secrets by their key name directly (e.g., `key: POSTGRES_PASSWORD`).
+This means any `ExternalSecret` using this store references secrets by their key name directly (e.g., `key: AUTHENTIK_SECRET_KEY`).
 
 ## How ExternalSecrets Work
 
@@ -136,8 +137,8 @@ sequenceDiagram
     CSS->>Infisical: POST /api/v1/auth/universal-auth/login
     Infisical-->>CSS: accessToken (JWT)
     ESO->>Infisical: GET /api/v3/secrets/raw?workspaceSlug=homelab&environment=prod
-    Infisical-->>ESO: { POSTGRES_PASSWORD: "abc123", ... }
-    ESO->>K8s: Create/Update Secret "postgresql-secret"
+    Infisical-->>ESO: { AUTHENTIK_SECRET_KEY: "abc123", ... }
+    ESO->>K8s: Create/Update Secret "authentik-secret"
     Note over ESO: Repeats every refreshInterval (1h)
 ```
 
@@ -264,7 +265,7 @@ flowchart TD
     D -- "InvalidProviderConfig\n403 Forbidden" --> F["Machine identity not added\nto homelab project in Infisical UI\n→ Project → Access Control → Add Identity"]
     D -- "InvalidProviderConfig\n404 Project not found" --> G["Project slug wrong\nCheck Infisical project settings\nEnsure slug = 'homelab'"]
     D -- "Valid / Ready: True" --> H["Store is fine, force ExternalSecret refresh:\nkubectl annotate externalsecret <name> -n <ns> force-sync=$(date +%s) --overwrite"]
-    B -- "secret key not found" --> I["Key name doesn't exist in Infisical\n→ Add it in Infisical UI\n→ homelab / prod / POSTGRES_PASSWORD etc."]
+    B -- "secret key not found" --> I["Key name doesn't exist in Infisical\n→ Add it in Infisical UI\n→ homelab / prod / AUTHENTIK_SECRET_KEY etc."]
 ```
 
 | Symptom | Cause | Fix |

--- a/docs/trivy-dashboard.md
+++ b/docs/trivy-dashboard.md
@@ -1,0 +1,7 @@
+---
+title: Trivy Dashboard
+---
+
+{%
+   include-markdown "../k8s/apps/trivy-dashboard/README.md"
+%}

--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -119,7 +119,6 @@ tailscale serve --bg http://localhost:30500
 |---|---|---|
 | Grafana | `auth.generic_oauth` | `https://holdens-mac-mini.story-larch.ts.net:8444` |
 | ArgoCD | `oidc.config` | `https://holdens-mac-mini.story-larch.ts.net:8443` |
-| Gitea | OAuth2 source | `https://holdens-mac-mini.story-larch.ts.net:8446` |
 | Infisical | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8445` |
 | Trivy Dashboard | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8448` |
 | Homelab Docs | Bookmark | `https://holdennguyen.github.io/homelab` |

--- a/k8s/apps/trivy-dashboard/README.md
+++ b/k8s/apps/trivy-dashboard/README.md
@@ -56,6 +56,10 @@ flowchart LR
 | Tailscale HTTPS | 8448 |
 | URL | `https://holdens-mac-mini.story-larch.ts.net:8448` |
 
+## Configuration
+
+OpenTelemetry is disabled by default via environment variables in the deployment to avoid unnecessary crash loops when no OTel collector is present.
+
 ## Updating
 
 To upgrade the dashboard image, update the tag in `deployment.yaml`:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,3 +54,4 @@ nav:
       - Monitoring: monitoring.md
       - OpenClaw: openclaw.md
       - Trivy Operator: trivy-operator.md
+      - Trivy Dashboard: trivy-dashboard.md

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -45,7 +45,7 @@ flowchart TD
 | `argocd.tf` | ArgoCD Helm release, Infisical Application CR, root App of Apps |
 | `bootstrap-secrets.tf` | Namespaces and the three bootstrap K8s Secrets |
 | `variables.tf` | All variable declarations with descriptions and types |
-| `outputs.tf` | Post-apply instructions and access URLs |
+| `outputs.tf` | Post-apply instructions, Tailscale Serve commands, and access URLs |
 | `terraform.tfvars` | **Gitignored.** Actual sensitive values — copy from `terraform.tfvars.example` |
 | `terraform.tfvars.example` | Template showing all required variables with placeholder values |
 | `.terraform.lock.hcl` | Provider version lock file — committed to git |


### PR DESCRIPTION
## Summary

- Add trivy-dashboard service to root README (architecture diagram, repo structure, deployed services, Tailscale Serve commands, doc index), architecture.md, and bootstrap.md
- Add trivy-dashboard MkDocs wrapper (`docs/trivy-dashboard.md`) and nav entry
- Add trivy-dashboard to `.doc-manifest.yml` freshness tracking
- Remove stale Gitea OAuth2 entry from Authentik application inventory
- Update `docs/secret-management.md`: replace postgresql-secret examples with authentik-secret, add missing GEMINI_API_KEY to Infisical diagram
- Add GITHUB_TOKEN to root README secrets table; fix skill count (9 → 8)
- Touch terraform/README.md, ai-agents.md, trivy-dashboard/README.md to resolve freshness drift
- Add v1.2.0 completion summary to root README

## Doc freshness

```
All documentation is up-to-date. (18/18)
```

This is the pre-release doc sweep for v1.2.0. After merge, the release tag can be created.


Made with [Cursor](https://cursor.com)