### PR TITLE
fix: explicitly enable Discord plugin for read-only ConfigMap

### DIFF
--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -481,12 +481,22 @@ The bot routes all messages to the `homelab-admin` orchestrator, which can deleg
 
 ### Configuration Reference
 
-The Discord channel is configured in `configmap.yaml` under `channels.discord`:
+Discord requires two config sections in `openclaw.json`:
+
+**Channel config** (`channels.discord`):
 
 | Key | Value | Purpose |
 |---|---|---|
 | `enabled` | `true` | Activate the Discord channel on startup |
 | `groupPolicy` | `"open"` | Allow messages from all guild channels (mention-gating still applies) |
+
+**Plugin entry** (`plugins.entries.discord`):
+
+| Key | Value | Purpose |
+|---|---|---|
+| `enabled` | `true` | Load the Discord extension plugin at startup |
+
+The plugin entry is required because the ConfigMap is mounted read-only. OpenClaw normally auto-enables channel plugins by writing to the config file at startup, but this fails on a read-only filesystem. Explicitly setting `plugins.entries.discord.enabled: true` in the ConfigMap bypasses the auto-enable write.
 
 The bot token is resolved from the `DISCORD_BOT_TOKEN` environment variable (injected via ESO from Infisical). No token is stored in the config file.
 
@@ -636,6 +646,7 @@ The `openclaw.json` config (in `configmap.yaml`) contains these key settings:
 | `agents.list[].subagents` | `allowAgents` | Per-agent list | Controls which agents each agent can spawn — only the orchestrator has non-empty lists |
 | `channels.discord` | `enabled` | `true` | Connect to Discord on startup using `DISCORD_BOT_TOKEN` env var |
 | `channels.discord` | `groupPolicy` | `"open"` | Respond in any guild channel the bot can see (mention required) |
+| `plugins.entries.discord` | `enabled` | `true` | Load Discord extension plugin (required for read-only ConfigMap) |
 
 ## Multi-Agent & Skills Architecture
 

--- a/k8s/apps/openclaw/configmap.yaml
+++ b/k8s/apps/openclaw/configmap.yaml
@@ -91,6 +91,11 @@ data:
           "extraDirs": ["/skills"]
         }
       },
+      "plugins": {
+        "entries": {
+          "discord": { "enabled": true }
+        }
+      },
       "tools": {
         "agentToAgent": {
           "enabled": true,


### PR DESCRIPTION
## Summary

- Fix Discord channel not showing as configured in the OpenClaw Gateway UI
- The Discord extension plugin was not loading because OpenClaw's auto-enable mechanism fails on a read-only ConfigMap mount (`EROFS: read-only file system`)
- Add `plugins.entries.discord.enabled: true` to `openclaw.json` so the plugin loads statically without needing a runtime config write

## Root cause

OpenClaw detects `DISCORD_BOT_TOKEN` in the environment and attempts to auto-enable the Discord plugin by writing `plugins.entries.discord.enabled = true` to the config file. Since the config is mounted from a read-only ConfigMap, the write silently fails:

```
failed to persist plugin auto-enable changes: Error: EROFS: read-only file system
```

The UI then shows "Channel config schema unavailable" because the Discord plugin (which registers the schema) never loaded.

## Test plan

- [ ] After ArgoCD sync: pod starts, no `EROFS` errors in logs
- [ ] `config get plugins` shows `discord.enabled: true`
- [ ] `channels status` shows Discord as connected and running
- [ ] Gateway UI > Channels shows Discord with config schema available

Ref #74

Made with [Cursor](https://cursor.com)