### PR TITLE
feat: expand OpenClaw RBAC from namespace-only to targeted ClusterRole

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -108,12 +108,12 @@ Every service runs under a dedicated ServiceAccount with least-privilege permiss
 
 | Service | ServiceAccount | Scope | Permissions |
 |---|---|---|---|
-| OpenClaw | `openclaw` (ns: `openclaw`) | Namespace Role | Read pods, logs, secrets, configmaps, services, PVCs; create pods/exec |
+| OpenClaw | `openclaw` (ns: `openclaw`) | Namespace Role + ClusterRole | See [OpenClaw RBAC detail](#kubernetes-rbac) below |
 | ArgoCD | `argocd-*` (ns: `argocd`) | ClusterRole | Managed by Helm chart — application controller needs cluster-wide access to sync resources |
 | ESO | `external-secrets` (ns: `external-secrets`) | ClusterRole | Managed by Helm chart — needs cluster-wide access to create secrets in any namespace |
 | Monitoring | `kube-prometheus-stack-*` | ClusterRole | Managed by Helm chart — Prometheus needs cluster-wide metrics scraping |
 
-The previous `cluster-admin` ClusterRoleBinding on the OpenClaw ServiceAccount was removed in v1.1.0, scoping it down to a namespace-only Role.
+OpenClaw's RBAC was expanded from a namespace-only Role (v1.1.0–v1.3.0) to a namespace Role + targeted ClusterRole in v1.4.0. The ClusterRole grants cluster-wide read and scoped operational writes (rollout restart, force-sync, ArgoCD hard refresh) without granting `cluster-admin`. See the [full RBAC breakdown](#kubernetes-rbac) in the OpenClaw security section.
 
 ## Secret Management
 
@@ -215,14 +215,47 @@ This section provides a detailed breakdown of OpenClaw's permissions, access, an
 
 ### Kubernetes RBAC
 
-The `openclaw` ServiceAccount has a **namespace-scoped Role** (not a ClusterRole). It cannot access resources in any other namespace via the Kubernetes API.
+The `openclaw` ServiceAccount has two layers of RBAC:
+
+1. **Namespace Role** (`openclaw-role` in `openclaw` namespace) — namespace-specific permissions
+2. **ClusterRole** (`openclaw-homelab-admin`) — cluster-wide read + targeted operational writes
+
+#### Namespace Role (openclaw namespace only)
 
 | Resources | Verbs | Risk |
 |---|---|---|
-| pods, pods/log, secrets, configmaps, services, persistentvolumeclaims | get, list, watch | Low (read-only) |
+| secrets | get, list, watch | **Medium** — can read secrets in the `openclaw` namespace (API keys) |
 | pods/exec | create | **Medium** — allows shell access into pods in the `openclaw` namespace |
 
-Since only the OpenClaw pod itself runs in the namespace, `pods/exec` is effectively self-referential. However, if additional pods are ever deployed to the `openclaw` namespace, this permission would extend to them.
+Since only the OpenClaw pod itself runs in the namespace, `pods/exec` is effectively self-referential. Secrets read is limited to the `openclaw` namespace — the agent cannot read secrets in `argocd`, `monitoring`, `authentik`, or other namespaces.
+
+#### ClusterRole (cluster-wide)
+
+| Resources | Verbs | Purpose | Risk |
+|---|---|---|---|
+| pods, pods/log, services, endpoints, configmaps, events, nodes, namespaces, PVCs, PVs, replicationcontrollers | get, list, watch | Cluster-wide monitoring (`kubectl get pods -A`, `kubectl describe node`) | Low (read-only) |
+| deployments, statefulsets, daemonsets, replicasets | get, list, watch | Workload status across namespaces | Low (read-only) |
+| deployments, statefulsets | patch | Rollout restart (annotation), rollout undo | **Medium** — can restart or roll back any deployment |
+| deployments/scale, statefulsets/scale | get, patch | Emergency scaling (`kubectl scale`) | **Medium** — can scale to 0 (mitigated by Critical Risk Protocol) |
+| pods | delete | Remove stuck pods | Low |
+| configmaps, services, PVCs | patch | Annotate resources for troubleshooting | Low |
+| externalsecrets (external-secrets.io) | get, list, watch, patch | Check sync status, force-sync annotation | Low |
+| applications, appprojects (argoproj.io) | get, list, watch | Check ArgoCD sync status | Low (read-only) |
+| applications (argoproj.io) | patch | Hard refresh annotation | Low |
+| pods, nodes (metrics.k8s.io) | get, list | `kubectl top pods/nodes` | Low (read-only) |
+
+#### What the ClusterRole does NOT grant
+
+| Capability | Why excluded |
+|---|---|
+| **Create** deployments, services, namespaces, configmaps | Persistent resource creation goes through GitOps (git → ArgoCD) |
+| **Delete** deployments, services, statefulsets, namespaces | Destructive deletions go through GitOps (git revert → ArgoCD prune) |
+| **Read secrets** outside `openclaw` namespace | Secrets in `argocd`, `monitoring`, `authentik`, `infisical` are not accessible |
+| **Modify** ClusterRoles, ClusterRoleBindings, NetworkPolicies | Security-sensitive cluster resources are GitOps-only |
+| **Create/delete** ArgoCD Applications or AppProjects | Application lifecycle is managed through git manifests |
+| **Exec** into pods in other namespaces | pods/exec is namespace-scoped to `openclaw` only |
+
+This design allows the agent to **monitor everything, operate on running workloads, but never create or destroy infrastructure**. All persistent changes flow through GitOps.
 
 ### Secrets Accessible
 
@@ -364,13 +397,15 @@ flowchart LR
 | # | Risk | Severity | Current Mitigation | Residual Risk |
 |---|---|---|---|---|
 | 1 | `GITHUB_TOKEN` grants repo write access to all agents | Medium | Scoped to single repo; PR review required; agent footprint tracing | A misbehaving agent could create spam PRs or issues |
-| 2 | `pods/exec` + `secrets` read lets agents read their own secrets via kubectl | Medium | Only one pod in namespace; RBAC is namespace-scoped | If more pods are added to `openclaw` ns, blast radius grows |
-| 3 | Missing `allowPrivilegeEscalation: false` | Low | Container runs as non-root (UID 1000) | Theoretical escalation path if kernel vulnerability exists |
-| 4 | `--allow-unconfigured` on gateway | Low | Tailscale + gateway token + device pairing provide three auth layers | Removes one defense layer (client pre-registration) |
-| 5 | `trustedProxies` covers all RFC 1918 space | Low | Only OrbStack internal traffic uses these ranges | Broader than necessary; could be narrowed |
-| 6 | `sessions.visibility: "all"` | Low | Single-user system; no multi-tenant data | All agents see all session history |
-| 7 | Read-only hostPath volumes expose host filesystem | Low | Paths are narrow; read-only; contain only Markdown files | Container compromise could read skill/agent definitions |
-| 8 | LLM API keys grant inference access | Low | Keys are per-provider; usage-based billing with spending limits | Compromised key could incur API costs |
+| 2 | `pods/exec` + `secrets` read lets agents read their own secrets via kubectl | Medium | Only one pod in namespace; secrets read is namespace-scoped to `openclaw` | If more pods are added to `openclaw` ns, blast radius grows |
+| 3 | ClusterRole allows `patch` on deployments/statefulsets cluster-wide | Medium | Limited to patch (restart/scale) — cannot create or delete workloads; Critical Risk Protocol requires user confirmation for scaling to 0 | A misbehaving agent could restart or scale down any deployment |
+| 4 | ClusterRole allows `patch` on ArgoCD Applications | Low | Limited to patch (hard refresh annotation) — cannot create or delete Applications | Agent could trigger unnecessary refreshes; self-heal reverts any drift |
+| 5 | Missing `allowPrivilegeEscalation: false` | Low | Container runs as non-root (UID 1000) | Theoretical escalation path if kernel vulnerability exists |
+| 6 | `--allow-unconfigured` on gateway | Low | Tailscale + gateway token + device pairing provide three auth layers | Removes one defense layer (client pre-registration) |
+| 7 | `trustedProxies` covers all RFC 1918 space | Low | Only OrbStack internal traffic uses these ranges | Broader than necessary; could be narrowed |
+| 8 | `sessions.visibility: "all"` | Low | Single-user system; no multi-tenant data | All agents see all session history |
+| 9 | Read-only hostPath volumes expose host filesystem | Low | Paths are narrow; read-only; contain only Markdown files | Container compromise could read skill/agent definitions |
+| 10 | LLM API keys grant inference access | Low | Keys are per-provider; usage-based billing with spending limits | Compromised key could incur API costs |
 
 ### OpenClaw Hardening Recommendations
 
@@ -419,7 +454,7 @@ flowchart TD
 | **Container filesystem isolation** | The container has its own root filesystem. Only explicitly mounted volumes are visible. | Cannot see `/Users/holden.nguyen/`, cannot read Desktop/Documents/Downloads, cannot access Photos/Music/Mail, cannot read browser profiles or cookies |
 | **hostPath scope** | Two host directories are mounted — both read-only, both containing only Markdown files | Can read `agents/workspaces/*.md` and `skills/*.md`. Cannot write to them. Cannot mount additional host paths without changing the deployment manifest (which requires a PR + human review) |
 | **Non-root execution** | Pod runs as UID 1000 with `runAsNonRoot: true` | Cannot escalate to root inside the container, cannot modify system binaries, cannot change container network config |
-| **Namespace-scoped RBAC** | ServiceAccount has a Role (not ClusterRole) limited to the `openclaw` namespace | Cannot list/get/modify pods, secrets, or any resource in other namespaces (`argocd`, `monitoring`, `infisical`, `authentik`). Cannot create Deployments, DaemonSets, or any cluster-scoped resource |
+| **Targeted RBAC (no cluster-admin)** | ClusterRole grants cluster-wide read + scoped operational writes (restart, scale, annotate). Namespace Role grants secrets read + pods/exec in `openclaw` only | Cannot create or delete deployments, services, or namespaces. Cannot read secrets outside `openclaw`. Cannot modify ClusterRoles, NetworkPolicies, or RBAC resources. Cannot exec into pods in other namespaces |
 | **Network policies** | Default-deny with explicit allowlist: DNS, K8s API (:6443), Tailscale ingress (:18789), internet egress (:443) | Cannot reach other namespaces' pods over the network (declarative intent — enforcement depends on CNI). Cannot open arbitrary ports. Cannot reach macOS services on the host network (except through the K8s API server) |
 | **Secret scoping** | Only `openclaw-secret` is injected (5 API keys). Infisical stores all other secrets in separate ExternalSecrets per namespace | Cannot read Authentik passwords, Grafana credentials, PostgreSQL passwords, or any secret outside its namespace |
 | **GitHub token scope** | Fine-grained PAT: only `holdennguyen/homelab`, only code/issues/PRs | Cannot access other repos, cannot modify repo settings/webhooks, cannot access GitHub account settings, cannot read private repos beyond `homelab` |
@@ -436,8 +471,12 @@ To be precise about the actual attack surface:
 | `skills/*.md` via hostPath | Read-only | Minimal — only skill definition Markdown files |
 | `openclaw-secret` (5 API keys) | Read via env vars and `kubectl get secret` | Medium — LLM API keys could incur billing; GitHub token scoped to one repo |
 | Pods in `openclaw` namespace | Read + exec | Medium — only the OpenClaw pod itself runs there |
-| K8s API server | Scoped to `openclaw` namespace reads | Low |
-| Internet on port 443 | Outbound HTTPS | Required for LLM APIs and GitHub; could theoretically exfiltrate data from its own namespace |
+| Pods, deployments, services, events in **all** namespaces | Read-only | Low — monitoring only, cannot modify |
+| Deployments, statefulsets in **all** namespaces | Patch (restart, scale) | Medium — can restart or scale workloads; scaling to 0 is gated by Critical Risk Protocol |
+| ArgoCD Applications | Read + patch (hard refresh) | Low — can trigger syncs but cannot create/delete apps |
+| ExternalSecrets in **all** namespaces | Read + patch (force-sync) | Low — can check status and trigger re-sync |
+| Secrets **outside** `openclaw` namespace | **No access** | N/A — cannot read secrets in argocd, monitoring, authentik, infisical |
+| Internet on port 443 | Outbound HTTPS | Required for LLM APIs and GitHub; could theoretically exfiltrate data visible to the agent |
 
 ### What would need to change for OpenClaw to harm the host
 

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -65,7 +65,7 @@ flowchart TD
 | `configmap.yaml` | Multi-agent `openclaw.json` config (gateway, agents, channels, skills, tools) |
 | `deployment.yaml` | Single-replica deployment with config/skills/workspace volumes |
 | `service.yaml` | NodePort service exposing port 30789 |
-| `rbac.yaml` | ServiceAccount + ClusterRoleBinding (cluster-admin) |
+| `rbac.yaml` | ServiceAccount + namespace Role + ClusterRole (`openclaw-homelab-admin`) |
 | `kustomization.yaml` | Kustomize resource list |
 
 Related files outside this directory:
@@ -92,7 +92,12 @@ This ensures that the container processes do not have root privileges on the hos
 
 Note: OpenClaw uses a `hostPath` volume to inject agent workspace definitions from the host (`/Users/holden.nguyen/homelab/agents/workspaces`). This is an exception to the cluster's default-deny network policies and requires the `openclaw` namespace to be exempt from the `restricted` pod security profile (due to the use of `hostPath`).
 
-The OpenClaw service account is scoped to its own namespace via a Role with minimal permissions: read-only access to pods, logs, secrets, configmaps, services, and PVCs, plus exec into pods for debugging. The previous `cluster-admin` ClusterRoleBinding has been removed, limiting the blast radius if the service account token were compromised.
+The OpenClaw ServiceAccount has a two-layer RBAC model:
+
+- **Namespace Role** (`openclaw-role`) — secrets read + pods/exec in the `openclaw` namespace only
+- **ClusterRole** (`openclaw-homelab-admin`) — cluster-wide read on pods, deployments, services, events, nodes, namespaces, and workload resources; targeted operational writes including patch on deployments/statefulsets (rollout restart, scale), patch on ExternalSecrets (force-sync), and patch on ArgoCD Applications (hard refresh). Does not grant create/delete on any resource, secrets read outside `openclaw`, or any cluster-scoped resource modification (ClusterRoles, NetworkPolicies, namespaces).
+
+This gives the homelab-admin agent the ability to monitor everything and operate on running workloads, while all persistent infrastructure changes flow through GitOps. See [docs/security.md](../../docs/security.md) for the full RBAC breakdown.
 
 ## How It Fits in the Homelab
 
@@ -722,7 +727,7 @@ When the primary model fails, OpenClaw automatically falls through to Gemini. Au
 
 Agent configuration is in the `openclaw-config` ConfigMap (mounted at `/config/openclaw.json`). Each agent has its own AGENTS.md personality file in `agents/workspaces/<id>/AGENTS.md`, copied into the pod workspace on every restart by the `init-workspaces` init container.
 
-The pod runs with a `cluster-admin` ServiceAccount so agents can execute `kubectl`, `helm`, and other ops tools against the cluster directly.
+The pod runs with a dedicated ServiceAccount (`openclaw`) that has a targeted ClusterRole (`openclaw-homelab-admin`) — cluster-wide read plus scoped operational writes (restart, scale, annotate). Agents execute `kubectl`, `helm`, and other ops tools against the cluster, bounded by these RBAC permissions.
 
 ### Skills
 

--- a/k8s/apps/openclaw/rbac.yaml
+++ b/k8s/apps/openclaw/rbac.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: openclaw
     app.kubernetes.io/instance: openclaw
 ---
+# Namespace Role: openclaw-specific permissions (secrets read + pods/exec)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -15,12 +16,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-    - pods
-    - pods/log
     - secrets
-    - configmaps
-    - services
-    - persistentvolumeclaims
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources:
@@ -36,6 +32,97 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: openclaw-role
+subjects:
+- kind: ServiceAccount
+  name: openclaw
+  namespace: openclaw
+---
+# ClusterRole: cluster-wide read + targeted operational writes
+# Gives homelab-admin the ability to monitor all namespaces, restart
+# deployments, force-sync ExternalSecrets, and manage ArgoCD Applications.
+# Does NOT grant: create/delete deployments, services, namespaces, or
+# cluster-scoped resources. Persistent changes go through GitOps.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openclaw-homelab-admin
+rules:
+# Cluster-wide read: core resources
+- apiGroups: [""]
+  resources:
+    - pods
+    - pods/log
+    - services
+    - endpoints
+    - configmaps
+    - events
+    - nodes
+    - namespaces
+    - persistentvolumeclaims
+    - persistentvolumes
+    - replicationcontrollers
+  verbs: ["get", "list", "watch"]
+# Cluster-wide read: workload resources
+- apiGroups: ["apps"]
+  resources:
+    - deployments
+    - statefulsets
+    - daemonsets
+    - replicasets
+  verbs: ["get", "list", "watch"]
+# Operational writes: rollout restart (patch annotation), scale
+- apiGroups: ["apps"]
+  resources:
+    - deployments
+    - statefulsets
+  verbs: ["patch"]
+- apiGroups: ["apps"]
+  resources:
+    - deployments/scale
+    - statefulsets/scale
+  verbs: ["get", "patch"]
+# Operational writes: delete stuck pods
+- apiGroups: [""]
+  resources:
+    - pods
+  verbs: ["delete"]
+# Operational writes: annotate resources (force-sync, etc.)
+- apiGroups: [""]
+  resources:
+    - configmaps
+    - services
+    - persistentvolumeclaims
+  verbs: ["patch"]
+# ExternalSecrets: read status + patch for force-sync annotation
+- apiGroups: ["external-secrets.io"]
+  resources:
+    - externalsecrets
+  verbs: ["get", "list", "watch", "patch"]
+# ArgoCD Applications: read status + patch for hard refresh annotation
+- apiGroups: ["argoproj.io"]
+  resources:
+    - applications
+    - appprojects
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["argoproj.io"]
+  resources:
+    - applications
+  verbs: ["patch"]
+# Resource metrics: kubectl top pods/nodes
+- apiGroups: ["metrics.k8s.io"]
+  resources:
+    - pods
+    - nodes
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openclaw-homelab-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openclaw-homelab-admin
 subjects:
 - kind: ServiceAccount
   name: openclaw

--- a/skills/homelab-admin/SKILL.md
+++ b/skills/homelab-admin/SKILL.md
@@ -25,7 +25,9 @@ Orchestrate and manage the homelab Kubernetes cluster running on OrbStack (Mac m
 - **Manifests:** Kustomize for app workloads; Helm only for upstream charts (ESO, Infisical)
 - **Storage:** `local-path` provisioner (OrbStack default)
 - **Container image:** OpenClaw runs a custom image (`openclaw:latest`) built with `Dockerfile.openclaw`, which includes kubectl, helm, terraform, argocd, jq, git, gh
-- **Pod RBAC:** This pod's ServiceAccount has a namespace-scoped Role in `openclaw` with read-only access to pods, logs, secrets, configmaps, services, PVCs, and exec into pods. It does NOT have cluster-wide access.
+- **Pod RBAC:** This pod's ServiceAccount has two RBAC layers:
+  - **Namespace Role** (`openclaw-role`): secrets read + pods/exec in `openclaw` namespace
+  - **ClusterRole** (`openclaw-homelab-admin`): cluster-wide read on all common resources; patch on deployments/statefulsets (rollout restart, scale); patch on ExternalSecrets (force-sync); patch on ArgoCD Applications (hard refresh); delete pods (stuck pods); metrics read (`kubectl top`). Does NOT grant create/delete on infrastructure resources, secrets read outside `openclaw`, or modification of ClusterRoles/NetworkPolicies/namespaces.
 
 ## Tailscale network
 


### PR DESCRIPTION
## Summary

- Adds ClusterRole `openclaw-homelab-admin` giving the OpenClaw agent cluster-wide read access plus scoped operational writes
- Keeps namespace Role for `openclaw`-specific permissions (secrets read, pods/exec)
- Updates security documentation with full RBAC breakdown, risk summary, and host isolation model corrections
- Updates OpenClaw README and homelab-admin skill to reflect actual RBAC

## RBAC Design

**Cluster-wide read** (monitoring):
- Core: pods, pods/log, services, endpoints, configmaps, events, nodes, namespaces, PVCs, PVs
- Workloads: deployments, statefulsets, daemonsets, replicasets
- CRDs: ExternalSecrets, ArgoCD Applications/AppProjects
- Metrics: pods, nodes (for `kubectl top`)

**Targeted operational writes**:
- `patch` deployments/statefulsets — rollout restart, rollout undo
- `patch` deployments/scale, statefulsets/scale — emergency scaling
- `delete` pods — remove stuck pods
- `patch` ExternalSecrets — force-sync annotation
- `patch` ArgoCD Applications — hard refresh annotation
- `patch` configmaps, services, PVCs — annotation for troubleshooting

**Explicitly excluded** (stays GitOps-only):
- Create/delete deployments, services, namespaces, configmaps
- Read secrets outside `openclaw` namespace
- Modify ClusterRoles, ClusterRoleBindings, NetworkPolicies
- Create/delete ArgoCD Applications or AppProjects
- pods/exec outside `openclaw` namespace

## Test plan
- [ ] ArgoCD syncs the new ClusterRole and ClusterRoleBinding
- [ ] `kubectl get pods -A` works from inside OpenClaw pod
- [ ] `kubectl rollout restart deployment/openclaw -n openclaw` works
- [ ] `kubectl get applications -n argocd` works
- [ ] `kubectl get externalsecret -A` works
- [ ] `kubectl top pods -A` works
- [ ] `kubectl get secret -n argocd` is denied (secrets read is namespace-scoped)
- [ ] `kubectl delete deployment -n argocd` is denied (no delete on workloads)


Made with [Cursor](https://cursor.com)