### PR TITLE
fix: Mermaid diagrams render as interactive diagrams instead of code blocks

### DIFF
--- a/.cursor/commands/pre-merge-check.md
+++ b/.cursor/commands/pre-merge-check.md
@@ -44,6 +44,17 @@ For modified K8s manifests, verify:
 - Namespaces exist or `CreateNamespace=true` is set
 - Container images use pinned tags (not `:latest` for upstream)
 
+### 6. Mermaid Syntax Check
+
+For modified `*.md` files containing mermaid blocks, verify:
+- No spaces in node IDs (use camelCase/PascalCase/underscores)
+- No `style`, `classDef`, or `:::` directives (break dark mode)
+- No reserved keywords as bare node IDs (`end`, `subgraph`, `graph`)
+- Edge labels with special characters are quoted: `-->|"label"|`
+- Node labels with parentheses/colons are double-quoted: `A["Label (detail)"]`
+
+Flag as **WARN** if any violations found. See the `/documentation` skill for the full mermaid conventions.
+
 ## Report Format
 
 Summarize results as a checklist:
@@ -52,3 +63,4 @@ Summarize results as a checklist:
 - [ ] Secret scan — PASS/FAIL
 - [ ] Doc freshness — PASS/WARN
 - [ ] Labels and conventions — PASS/FAIL
+- [ ] Mermaid syntax — PASS/WARN/N/A

--- a/.cursor/skills/documentation/SKILL.md
+++ b/.cursor/skills/documentation/SKILL.md
@@ -71,6 +71,20 @@ Every `k8s/apps/<service>/README.md` should include these sections (adapt as nee
 7. If the service has secrets, update `docs/secret-management.md` and `k8s/apps/infisical/README.md` inventory
 8. If the service has a Tailscale endpoint, update `docs/networking.md` and `docs/bootstrap.md` (Tailscale Serve commands)
 
+## Mermaid Diagram Conventions
+
+When writing mermaid diagrams in documentation:
+
+- **No spaces in node IDs** — use `camelCase`, `PascalCase`, or underscores (e.g., `UserService`, not `User Service`)
+- **Quote edge labels with special characters** — wrap in double quotes: `A -->|"O(1) lookup"| B`
+- **Quote node labels with special characters** — use double quotes: `A["Process (main)"]`
+- **Avoid reserved keywords as node IDs** — `end`, `subgraph`, `graph`, `flowchart` (use `endNode`, `processEnd` instead)
+- **No explicit colors or styling** — never use `style`, `classDef`, or `:::` syntax; they break dark mode. Let the MkDocs Material theme handle colors automatically
+- **Subgraph IDs** — use explicit IDs with labels: `subgraph authFlow [Authentication Flow]`
+- **No click events** — `click` syntax is disabled for security
+
+These conventions ensure diagrams render correctly in both light and dark mode on the MkDocs Material site.
+
 ## Rules
 
 - Keep docs concise — document the *what* and *why*, not step-by-step kubectl commands.

--- a/.cursor/skills/review/SKILL.md
+++ b/.cursor/skills/review/SKILL.md
@@ -27,6 +27,7 @@ For each service in `k8s/apps/<service>/`:
 - [ ] Networking table shows current ports/endpoints
 - [ ] Operational commands are tested and current
 - [ ] Troubleshooting table covers recent issues
+- [ ] Mermaid diagrams follow conventions (no `style`/`classDef`, no spaces in IDs, quoted special chars)
 - [ ] `docs/<service>.md` thin wrapper exists
 - [ ] Service listed in `mkdocs.yml` nav
 - [ ] Entry exists in `.doc-manifest.yml`

--- a/docs/security.md
+++ b/docs/security.md
@@ -441,9 +441,6 @@ flowchart TD
     Pod -. "BLOCKED\nno access" .-> FS
     Pod -. "BLOCKED\nno access" .-> Procs
     Pod -- "only HTTPS :443\n(LLM APIs, GitHub)" --> Net
-
-    style FS fill:#ff6b6b,color:#fff
-    style Procs fill:#ff6b6b,color:#fff
 ```
 
 ### Layer-by-layer breakdown
@@ -524,8 +521,6 @@ flowchart TD
     CallGW --> Twilio
     BankGW --> Plaid
     MsgGW & CallGW & BankGW --> AuditLog
-
-    style Keychain fill:#ff6b6b,color:#fff
 ```
 
 ### Design principles

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:pymdownx.superfences.fence_mermaid_format
   - pymdownx.tabbed:
       alternate_style: true
   - tables


### PR DESCRIPTION
## Summary

- Switch `mkdocs.yml` mermaid custom fence from `fence_code_format` to `fence_mermaid_format` so MkDocs Material renders mermaid blocks as interactive diagrams instead of raw code blocks
- Remove 3 `style` directives from `docs/security.md` mermaid diagrams that break dark mode
- Add mermaid conventions to `/documentation` skill, `/pre-merge-check` command, and `/review` skill so agents produce correct mermaid going forward

## Test plan

- [ ] Build docs locally with `mkdocs serve` and verify mermaid diagrams render on architecture, security, networking, secret-management, bootstrap, and ai-agents pages
- [ ] Toggle dark mode and verify diagrams remain legible
- [ ] Check browser console for mermaid syntax warnings

Closes #79

Made with [Cursor](https://cursor.com)