### PR TITLE
fix: Markdown bullet points render as proper lists instead of collapsed paragraphs

### DIFF
--- a/.cursor/commands/pre-merge-check.md
+++ b/.cursor/commands/pre-merge-check.md
@@ -44,7 +44,17 @@ For modified K8s manifests, verify:
 - Namespaces exist or `CreateNamespace=true` is set
 - Container images use pinned tags (not `:latest` for upstream)
 
-### 6. Mermaid Syntax Check
+### 6. Markdown Formatting Check
+
+For modified `*.md` files, verify:
+- Blank line before every bullet list (a text line followed directly by `- ` will collapse in MkDocs)
+- Blank line after headings
+- No trailing whitespace
+- Consistent list indentation (2 spaces for nesting)
+
+Flag as **WARN** if any violations found. See the `/documentation` skill for the full formatting rules.
+
+### 7. Mermaid Syntax Check
 
 For modified `*.md` files containing mermaid blocks, verify:
 - No spaces in node IDs (use camelCase/PascalCase/underscores)
@@ -63,4 +73,5 @@ Summarize results as a checklist:
 - [ ] Secret scan — PASS/FAIL
 - [ ] Doc freshness — PASS/WARN
 - [ ] Labels and conventions — PASS/FAIL
+- [ ] Markdown formatting — PASS/WARN/N/A
 - [ ] Mermaid syntax — PASS/WARN/N/A

--- a/.cursor/skills/documentation/SKILL.md
+++ b/.cursor/skills/documentation/SKILL.md
@@ -71,6 +71,16 @@ Every `k8s/apps/<service>/README.md` should include these sections (adapt as nee
 7. If the service has secrets, update `docs/secret-management.md` and `k8s/apps/infisical/README.md` inventory
 8. If the service has a Tailscale endpoint, update `docs/networking.md` and `docs/bootstrap.md` (Tailscale Serve commands)
 
+## Markdown Formatting Rules
+
+Follow these rules to ensure markdown renders correctly in MkDocs:
+
+- **Blank line before lists** — always add a blank line between a paragraph/text line and the first `- ` or `1. ` list item. Without it, some renderers collapse the list into the preceding paragraph.
+- **Blank line after headings** — always add a blank line after `#` headings before content.
+- **Consistent list indentation** — use 2 spaces for nested list items.
+- **No trailing whitespace** — remove trailing spaces on all lines.
+- **Blank line before and after code fences** — always add blank lines around ` ``` ` blocks.
+
 ## Mermaid Diagram Conventions
 
 When writing mermaid diagrams in documentation:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,7 @@ Terraform bootstraps the cluster exactly once. After `terraform apply`, no more 
 **Why Terraform for ArgoCD, not `kubectl apply`?**
 
 Every `kubectl apply` invocation is an untracked side-effect. Terraform tracks all resources in `terraform.tfstate`, which means:
+
 - `terraform plan` shows exactly what will change before applying
 - `terraform destroy` cleanly removes everything
 - The full bootstrap is reproducible from a fresh cluster with a single command
@@ -117,12 +118,14 @@ flowchart LR
 Every Application CR carries standard `app.kubernetes.io/*` labels (`name`, `part-of`, `component`, `managed-by`). See the [ArgoCD README](../k8s/apps/argocd/README.md#adding-a-new-application) for the full labeling rules and new-application template.
 
 **Branch protection** on `main`:
+
 - PRs require at least one approving review before merge
 - Force pushes and branch deletion are blocked
 - Linear history is required (no merge commits)
 - Admin bypass is available for emergencies (`enforce_admins: false`)
 
 **Sync policies** on all applications:
+
 - `automated.prune: true` — resources removed from git are deleted from the cluster
 - `automated.selfHeal: true` — any manual `kubectl` change is reverted within ~3 minutes
 - All applications target `targetRevision: HEAD` — every merge to `main` is deployed

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -115,6 +115,7 @@ flowchart LR
 > **ArgoCD OIDC client secret** is the only secret managed via Terraform instead of ESO (to avoid annotation-propagation conflicts with `argocd-secret`). All other secrets are pulled from Infisical by ESO.
 
 The ClusterSecretStore in `k8s/apps/external-secrets/cluster-secret-store.yaml` is configured with:
+
 - `projectSlug: homelab`
 - `environmentSlug: prod`
 - `secretsPath: /`

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -750,11 +750,13 @@ Skills follow the [AgentSkills](https://agentskills.io) format with OpenClaw-com
 ### Sub-agent spawning
 
 The orchestrator pattern uses `maxSpawnDepth: 2`:
+
 - **Depth 0** — main agent (`homelab-admin`) receives user requests
 - **Depth 1** — orchestrator spawns specialized sub-agents via `sessions_spawn`
 - **Depth 2** — sub-agents can spawn leaf workers for parallel tasks
 
 Sub-agents announce results back up the chain. Configure limits in the ConfigMap:
+
 - `maxConcurrent: 4` — max parallel sub-agents
 - `maxChildrenPerAgent: 3` — max children per agent session
 - `archiveAfterMinutes: 120` — auto-cleanup of finished sub-agent sessions


### PR DESCRIPTION
## Summary

- Add blank lines before bullet lists in `docs/architecture.md` (3 instances), `docs/secret-management.md` (1 instance), and `k8s/apps/openclaw/README.md` (2 instances) where lists immediately followed text, causing MkDocs to collapse them into single-line paragraphs
- Add "Markdown Formatting Rules" section to `/documentation` skill so agents produce correctly formatted markdown
- Add markdown formatting check (step 6) to `/pre-merge-check` command

## Test plan

- [ ] Build docs locally with `mkdocs serve` and verify bullet lists on architecture, secret-management, and OpenClaw pages render as proper `<ul><li>` elements
- [ ] Verify no other bullet lists collapsed on any page

Closes #80

Made with [Cursor](https://cursor.com)