### PR TITLE
fix: revert mermaid fence format to fence_code_format (deploy hotfix)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_mermaid_format
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - tables


### PR DESCRIPTION
## Summary

- Revert `mkdocs.yml` custom fence format from `fence_mermaid_format` (does not exist) back to `fence_code_format`
- `fence_mermaid_format` was introduced in #82 but this function does not exist in `pymdownx.superfences`, causing the GitHub Actions docs deploy to fail

MkDocs Material renders mermaid client-side via JavaScript -- it detects `<pre class="mermaid"><code>` blocks created by `fence_code_format` and initializes mermaid.js automatically. The `fence_code_format` was the correct configuration all along.

## Test plan

- [x] Local `mkdocs build` succeeds with `fence_code_format`
- [ ] GitHub Actions docs deploy passes after merge

Fixes the deploy failure from #82.

Made with [Cursor](https://cursor.com)