### PR TITLE
fix: resolve vikunja deployment failures and harden security posture

### DIFF
--- a/k8s/apps/argocd/README.md
+++ b/k8s/apps/argocd/README.md
@@ -33,6 +33,7 @@ flowchart TD
         ArgoDir -- "creates" --> TrivyApp["Application: trivy-operator"]
         ArgoDir -- "creates" --> TrivyScannerApp["Application: trivy-operator-vulnerability-scanner"]
         ArgoDir -- "creates" --> TrivyDashApp["Application: trivy-dashboard"]
+        ArgoDir -- "creates" --> VikApp["Application: vikunja"]
         ArgoDir -- "creates" --> NSApp["Application: namespace-security"]
         ArgoDir -- "creates" --> NPApp["Application: networking-policies"]
     end
@@ -58,6 +59,7 @@ flowchart TD
 | `applications/trivy-operator-app.yaml` | Trivy vulnerability scanner Helm chart (monitoring namespace, ClientServer mode) |
 | `applications/trivy-dashboard-app.yaml` | Trivy Operator Dashboard web UI (trivy-dashboard namespace) |
 | `applications/trivy-operator-vulnerability-scanner-app.yaml` | Trivy VulnerabilityScanner CR for scheduled daily scans |
+| `applications/vikunja-app.yaml` | Vikunja todo list application |
 | `applications/namespace-security-app.yaml` | Pod Security Standard labels for namespaces |
 | `applications/networking-policies-app.yaml` | Default-deny NetworkPolicies across all namespaces |
 
@@ -89,6 +91,7 @@ flowchart LR
         A7["openclaw"]
         A8["trivy-operator"]
         A11["trivy-dashboard"]
+        A12["vikunja"]
         A9["namespace-security"]
         A10["networking-policies"]
     end

--- a/k8s/apps/argocd/applications/vikunja-app.yaml
+++ b/k8s/apps/argocd/applications/vikunja-app.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: productivity
     app.kubernetes.io/managed-by: argocd
 spec:
-  project: default
+  project: apps
   source:
     repoURL: https://github.com/holdennguyen/homelab.git
     targetRevision: HEAD

--- a/k8s/apps/argocd/projects/apps.yaml
+++ b/k8s/apps/argocd/projects/apps.yaml
@@ -23,6 +23,8 @@ spec:
       namespace: authentik
     - server: https://kubernetes.default.svc
       namespace: trivy-dashboard
+    - server: https://kubernetes.default.svc
+      namespace: vikunja
   clusterResourceWhitelist:
     - group: ""
       kind: Namespace

--- a/k8s/apps/namespace-security/namespaces.yaml
+++ b/k8s/apps/namespace-security/namespaces.yaml
@@ -48,3 +48,13 @@ metadata:
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted
+---
+# vikunja: all pods run as non-root (vikunja UID 1000, postgresql UID 70)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vikunja
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/k8s/apps/networking-policies/policies.yaml
+++ b/k8s/apps/networking-policies/policies.yaml
@@ -551,3 +551,71 @@ spec:
     - protocol: TCP
       port: 8080
 
+---
+# VIKUNJA NAMESPACE
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: vikunja
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: vikunja
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector: {}
+  egress:
+  - to:
+    - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: vikunja
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-tailscale-ingress
+  namespace: vikunja
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 100.64.0.0/10
+    ports:
+    - protocol: TCP
+      port: 3456
+

--- a/k8s/apps/vikunja/README.md
+++ b/k8s/apps/vikunja/README.md
@@ -5,7 +5,7 @@ Vikunja is a self-hosted, feature-rich todo list and task management application
 ## Architecture
 
 This deployment consists of:
-- PostgreSQL database (StatefulSet) for data persistence
+- PostgreSQL database (Deployment with PVC) for data persistence
 - Vikunja application server (Deployment)
 - Kubernetes Services for internal and external access
 - Prometheus ServiceMonitor for metrics collection
@@ -85,7 +85,7 @@ kubectl logs -n vikunja deploy/vikunja
 
 ### Changing the Vikunja version
 
-Edit `k8s/apps/vikunja/vikunja-deployment.yaml` and update the `image` tag (e.g., `vikunja/vikunja:v0.18.0`). Then commit and push; ArgoCD will roll out the update.
+Edit `k8s/apps/vikunja/vikunja-deployment.yaml` and update the `image` tag (e.g., `vikunja/vikunja:1.1.0`). Then commit and push; ArgoCD will roll out the update.
 
 ### Backing up the database
 

--- a/k8s/apps/vikunja/postgresql-deployment.yaml
+++ b/k8s/apps/vikunja/postgresql-deployment.yaml
@@ -22,10 +22,10 @@ spec:
         app.kubernetes.io/part-of: vikunja
     spec:
       securityContext:
-        runAsUser: 999
-        runAsGroup: 999
+        runAsUser: 70
+        runAsGroup: 70
         runAsNonRoot: true
-        fsGroup: 999
+        fsGroup: 70
       containers:
         - name: postgresql
           image: postgres:15-alpine

--- a/k8s/apps/vikunja/vikunja-deployment.yaml
+++ b/k8s/apps/vikunja/vikunja-deployment.yaml
@@ -22,13 +22,13 @@ spec:
         app.kubernetes.io/part-of: vikunja
     spec:
       securityContext:
-        runAsUser: 999
-        runAsGroup: 999
+        runAsUser: 1000
+        runAsGroup: 1000
         runAsNonRoot: true
-        fsGroup: 999
+        fsGroup: 1000
       containers:
         - name: vikunja
-          image: vikunja/vikunja:latest
+          image: vikunja/vikunja:1.1.0
           imagePullPolicy: IfNotPresent
           env:
             - name: VIKUNJA_DB_TYPE
@@ -67,6 +67,22 @@ spec:
           ports:
             - containerPort: 3456
               name: http
+          livenessProbe:
+            httpGet:
+              path: /api/v1/info
+              port: 3456
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /api/v1/info
+              port: 3456
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
           volumeMounts:
             - name: files
               mountPath: /app/files


### PR DESCRIPTION
## Summary

Closes #86

The Vikunja deployment merged in PR #87 was not starting due to multiple misconfigurations. Three hotfix commits were applied directly to `main` (ExternalSecret apiVersion, missing env vars, ServiceMonitor field) but the core blockers remained.

### Root causes identified and fixed

- **PostgreSQL `runAsUser: 999` → `70`**: `postgres:15-alpine` has `postgres:x:70:70`. UID 999 does not exist in the container's `/etc/passwd`, causing `initdb` to fail with "could not look up effective user ID 999"
- **Vikunja `runAsUser: 999` → `1000`**: Upstream Dockerfile sets `USER 1000`. Mismatch caused file permission issues
- **ArgoCD Application `project: default` → `apps`**: `default` is reserved for the root App of Apps per conventions
- **`vikunja` namespace missing from `apps` project destinations**: ArgoCD would reject syncing to an unauthorized namespace
- **No NetworkPolicies**: All other namespaces use default-deny; vikunja had none
- **No Pod Security Standards labels**: Added `baseline` enforce with `restricted` audit/warn
- **No health probes on Vikunja**: Added `httpGet` liveness/readiness on `/api/v1/info`
- **Mutable `:latest` image tag**: Pinned to `vikunja/vikunja:1.1.0`

### Files changed (8 files)

| File | Change |
|---|---|
| `postgresql-deployment.yaml` | securityContext UID 999 → 70 |
| `vikunja-deployment.yaml` | securityContext UID 999 → 1000, pin image, add probes |
| `vikunja-app.yaml` | project: default → apps |
| `apps.yaml` (project) | add vikunja namespace destination |
| `policies.yaml` | add vikunja namespace NetworkPolicies |
| `namespaces.yaml` | add vikunja PSS labels |
| ArgoCD `README.md` | add vikunja to diagrams and file listing |
| Vikunja `README.md` | fix StatefulSet → Deployment, version example |

## Test plan

- [ ] ArgoCD syncs the `vikunja` Application without errors (project: apps, namespace allowed)
- [ ] PostgreSQL pod starts and passes readiness probe (`pg_isready`)
- [ ] Vikunja pod starts and passes readiness probe (`/api/v1/info` returns 200)
- [ ] Vikunja UI accessible via Tailscale at `http://<node-ip>:30888`
- [ ] NetworkPolicies applied: `kubectl get networkpolicy -n vikunja` shows 4 policies
- [ ] PSS labels applied: `kubectl get ns vikunja --show-labels` shows enforce=baseline


Made with [Cursor](https://cursor.com)