### PR TITLE
fix: correct Vikunja environment variable names for v1.x

### DIFF
--- a/k8s/apps/vikunja/vikunja-deployment.yaml
+++ b/k8s/apps/vikunja/vikunja-deployment.yaml
@@ -31,39 +31,33 @@ spec:
           image: vikunja/vikunja:1.1.0
           imagePullPolicy: IfNotPresent
           env:
-            - name: VIKUNJA_DB_TYPE
+            - name: VIKUNJA_DATABASE_TYPE
               value: postgres
-            - name: VIKUNJA_DB_HOST
+            - name: VIKUNJA_DATABASE_HOST
               value: postgresql.vikunja.svc.cluster.local
-            - name: VIKUNJA_DB_PORT
-              value: "5432"
-            - name: VIKUNJA_DB_USER
+            - name: VIKUNJA_DATABASE_USER
               valueFrom:
                 secretKeyRef:
                   name: vikunja-db-secret
                   key: POSTGRES_USER
-            - name: VIKUNJA_DB_PASSWORD
+            - name: VIKUNJA_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: vikunja-db-secret
                   key: VIKUNJA_DB_PASSWORD
-            - name: VIKUNJA_DB_DATABASE
+            - name: VIKUNJA_DATABASE_DATABASE
               valueFrom:
                 secretKeyRef:
                   name: vikunja-db-secret
                   key: POSTGRES_DB
-            - name: VIKUNJA_SERVICE_PORT
-              value: "3456"
             - name: VIKUNJA_SERVICE_PUBLICURL
               value: "http://vikunja.vikunja.svc.cluster.local"
-            - name: VIKUNJA_FRONTEND_URL
-              value: "http://vikunja.vikunja.svc.cluster.local"
-            - name: VIKUNJA_CACHE_DIR
-              value: "/tmp/.cache"
+            - name: VIKUNJA_SERVICE_TIMEZONE
+              value: "UTC"
             - name: VIKUNJA_MAILER_ENABLED
               value: "false"
-            - name: VIKUNJA_TIMEZONE
-              value: "UTC"
+            - name: VIKUNJA_FILES_BASEPATH
+              value: "/app/files"
           ports:
             - containerPort: 3456
               name: http


### PR DESCRIPTION
## Summary

Closes the remaining pod crash from #86 / PR #88.

**Root cause:** Vikunja v1.x uses `VIKUNJA_DATABASE_*` environment variable prefix (derived from config path `database.*`), not `VIKUNJA_DB_*`. Every database env var was silently ignored, causing Vikunja to fall back to its default SQLite backend. The scratch-based image has no `/db` directory, so the process crashes immediately on startup.

### Environment variable corrections

| Before (wrong) | After (correct) | Reason |
|---|---|---|
| `VIKUNJA_DB_TYPE` | `VIKUNJA_DATABASE_TYPE` | `database.type` |
| `VIKUNJA_DB_HOST` | `VIKUNJA_DATABASE_HOST` | `database.host` |
| `VIKUNJA_DB_USER` | `VIKUNJA_DATABASE_USER` | `database.user` |
| `VIKUNJA_DB_PASSWORD` | `VIKUNJA_DATABASE_PASSWORD` | `database.password` |
| `VIKUNJA_DB_DATABASE` | `VIKUNJA_DATABASE_DATABASE` | `database.database` |
| `VIKUNJA_TIMEZONE` | `VIKUNJA_SERVICE_TIMEZONE` | `service.timezone` |
| `VIKUNJA_DB_PORT` | *(removed)* | No such config; default 5432 |
| `VIKUNJA_SERVICE_PORT` | *(removed)* | No such config; default `:3456` |
| `VIKUNJA_FRONTEND_URL` | *(removed)* | Does not exist |
| `VIKUNJA_CACHE_DIR` | *(removed)* | Does not exist |
| *(missing)* | `VIKUNJA_FILES_BASEPATH=/app/files` | Match PVC mount path |

Reference: https://vikunja.io/docs/config-options

## Test plan

- [ ] Vikunja pod starts without CrashLoopBackOff
- [ ] `kubectl logs -n vikunja deploy/vikunja` shows successful PostgreSQL connection
- [ ] Vikunja readiness probe (`/api/v1/info`) returns 200
- [ ] UI accessible via `http://<tailscale-ip>:30888`


Made with [Cursor](https://cursor.com)