### PR TITLE
fix: align Vikunja secret keys with Infisical naming convention

### DIFF
--- a/k8s/apps/external-secrets/README.md
+++ b/k8s/apps/external-secrets/README.md
@@ -193,6 +193,7 @@ env:
 | `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password` | Authentik server + worker pods; embedded PostgreSQL |
 | `grafana-secret` | `monitoring` | `grafana-secret` | `admin-user`, `admin-password`, `oauth-client-id`, `oauth-client-secret` | Grafana admin login; Grafana OIDC via Authentik |
 | `openclaw-secret` | `openclaw` | `openclaw-secret` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN` | OpenClaw gateway env vars, agent git workflow |
+| `vikunja-db-secret` | `vikunja` | `vikunja-db-secret` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` | PostgreSQL + Vikunja database credentials |
 
 ## Security
 

--- a/k8s/apps/vikunja/README.md
+++ b/k8s/apps/vikunja/README.md
@@ -29,16 +29,15 @@ This deployment consists of:
 
 ### 1. Create Infisical Secrets
 
-Before the first sync, add the following secrets to Infisical under the path `/homelab/prod/vikunja/` (or your chosen environment):
+Before the first sync, add the following secrets to Infisical under `homelab / prod / ` (root path):
 
 | Key | Description | Example |
 |-----|-------------|---------|
-| `POSTGRES_USER` | PostgreSQL superuser username | `vikunja` |
-| `POSTGRES_PASSWORD` | Password for the PostgreSQL user | (random strong password) |
-| `POSTGRES_DB` | PostgreSQL database name | `vikunja` |
-| `VIKUNJA_DB_PASSWORD` | Password used by Vikunja to connect (should match `POSTGRES_PASSWORD`) | (same as above) |
+| `VIKUNJA_POSTGRES_USER` | PostgreSQL superuser username | `vikunja` |
+| `VIKUNJA_POSTGRES_PASSWORD` | Password for the PostgreSQL user | (random strong password) |
+| `VIKUNJA_POSTGRES_DB` | PostgreSQL database name | `vikunja` |
 
-The External Secrets Operator will sync these into a `vikunja-db-secret` in the `vikunja` namespace.
+The External Secrets Operator will sync these into a `vikunja-db-secret` in the `vikunja` namespace. Both the PostgreSQL and Vikunja deployments share the same password key — no duplication needed.
 
 ### 2. Authentik Bookmark
 

--- a/k8s/apps/vikunja/external-secret.yaml
+++ b/k8s/apps/vikunja/external-secret.yaml
@@ -14,13 +14,10 @@ spec:
   data:
     - secretKey: POSTGRES_USER
       remoteRef:
-        key: POSTGRES_USER
+        key: VIKUNJA_POSTGRES_USER
     - secretKey: POSTGRES_PASSWORD
       remoteRef:
-        key: POSTGRES_PASSWORD
+        key: VIKUNJA_POSTGRES_PASSWORD
     - secretKey: POSTGRES_DB
       remoteRef:
-        key: POSTGRES_DB
-    - secretKey: VIKUNJA_DB_PASSWORD
-      remoteRef:
-        key: VIKUNJA_DB_PASSWORD
+        key: VIKUNJA_POSTGRES_DB

--- a/k8s/apps/vikunja/vikunja-deployment.yaml
+++ b/k8s/apps/vikunja/vikunja-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: vikunja-db-secret
-                  key: VIKUNJA_DB_PASSWORD
+                  key: POSTGRES_PASSWORD
             - name: VIKUNJA_DATABASE_DATABASE
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Closes the final secrets alignment for #86.

Prerequisite: Infisical UI has been updated with the renamed keys (`VIKUNJA_POSTGRES_USER`, `VIKUNJA_POSTGRES_PASSWORD`, `VIKUNJA_POSTGRES_DB`), and the old `VIKUNJA_DB_PASSWORD` has been deleted.

### Changes

- **ExternalSecret**: Updated `remoteRef.key` values to match the renamed Infisical keys; removed the redundant `VIKUNJA_DB_PASSWORD` entry (4 keys → 3)
- **Vikunja deployment**: Changed `VIKUNJA_DATABASE_PASSWORD` secretKeyRef from `VIKUNJA_DB_PASSWORD` to `POSTGRES_PASSWORD` — same canonical key PostgreSQL uses
- **Vikunja README**: Corrected Infisical setup table (3 keys, `VIKUNJA_POSTGRES_*` prefix, root path)
- **ESO README**: Added `vikunja-db-secret` to the current ExternalSecrets inventory table

### Secret flow after merge

```
Infisical (homelab/prod/)     K8s Secret key      Consumed by
─────────────────────────     ──────────────      ───────────
VIKUNJA_POSTGRES_USER     →   POSTGRES_USER    →  PostgreSQL + Vikunja
VIKUNJA_POSTGRES_PASSWORD →   POSTGRES_PASSWORD →  PostgreSQL + Vikunja
VIKUNJA_POSTGRES_DB       →   POSTGRES_DB      →  PostgreSQL + Vikunja
```

## Test plan

- [ ] ExternalSecret syncs: `kubectl get externalsecret -n vikunja` shows `SecretSynced`
- [ ] K8s Secret created: `kubectl get secret vikunja-db-secret -n vikunja` exists with 3 keys
- [ ] PostgreSQL pod starts and passes readiness probe
- [ ] Vikunja pod connects to PostgreSQL (no auth errors in logs)
- [ ] Vikunja UI accessible via `http://<tailscale-ip>:30888`


Made with [Cursor](https://cursor.com)