### PR TITLE
fix: resolve ArgoCD shared resource conflict on vikunja Namespace

### DIFF
--- a/k8s/apps/namespace-security/namespaces.yaml
+++ b/k8s/apps/namespace-security/namespaces.yaml
@@ -55,6 +55,10 @@ kind: Namespace
 metadata:
   name: vikunja
   labels:
+    name: vikunja
+    app.kubernetes.io/name: vikunja
+    app.kubernetes.io/part-of: homelab
+    app.kubernetes.io/managed-by: argocd
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/warn: restricted

--- a/k8s/apps/vikunja/kustomization.yaml
+++ b/k8s/apps/vikunja/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: vikunja
 
 resources:
-  - namespace.yaml
   - external-secret.yaml
   - postgresql-pvc.yaml
   - postgresql-service.yaml

--- a/k8s/apps/vikunja/namespace.yaml
+++ b/k8s/apps/vikunja/namespace.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vikunja
-  labels:
-    name: vikunja
-    app.kubernetes.io/name: vikunja
-    app.kubernetes.io/part-of: homelab
-    app.kubernetes.io/managed-by: argocd


### PR DESCRIPTION
## Summary

Fixes the ArgoCD sync blocker for #86.

**Root cause:** ArgoCD refuses to sync because `Namespace/vikunja` is declared by both the `vikunja` Application (via `namespace.yaml`) and the `namespace-security` Application (via `namespaces.yaml`). ArgoCD treats this as a shared resource conflict and blocks automated sync.

### Changes

- Remove `namespace.yaml` from vikunja directory and kustomization — the `CreateNamespace=true` syncOption already handles namespace creation
- Merge the homelab labels (`name`, `app.kubernetes.io/*`) into the namespace-security entry so the namespace retains full metadata

### After merge

ArgoCD sync will unblock. The `postgresql-data` PVC has already been deleted (stale UID 999 data) and will be recreated by ArgoCD, allowing PostgreSQL to initialize fresh with the correct UID 70.

## Test plan

- [ ] ArgoCD vikunja Application shows `Synced Healthy` (no more shared resource error)
- [ ] `kubectl get pvc -n vikunja` shows `postgresql-data` recreated and Bound
- [ ] PostgreSQL pod starts, runs `initdb`, passes readiness probe
- [ ] Vikunja pod connects to PostgreSQL and passes readiness probe
- [ ] `kubectl get ns vikunja --show-labels` includes both homelab and PSS labels


Made with [Cursor](https://cursor.com)