### PR TITLE
feat: fix vikunja OutOfSync and add Authentik portal bookmark

### DIFF
--- a/k8s/apps/argocd/applications/vikunja-app.yaml
+++ b/k8s/apps/argocd/applications/vikunja-app.yaml
@@ -25,4 +25,3 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true

--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -122,6 +122,7 @@ tailscale serve --bg http://localhost:30500
 | Infisical | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8445` |
 | OpenClaw | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8447` |
 | Trivy Dashboard | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8448` |
+| Vikunja | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8449` |
 | Homelab Docs | Bookmark | `https://holdennguyen.github.io/homelab` |
 
 ## Adding a new Bookmark Application

--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -55,3 +55,15 @@ data:
           meta_icon: https://avatars.githubusercontent.com/u/252820863?s=48&v=4
           meta_description: AI Agent Gateway Console
           meta_publisher: Homelab
+      - model: authentik_core.application
+        id: app-vikunja
+        state: present
+        identifiers:
+          slug: vikunja
+        attrs:
+          name: Vikunja
+          group: Productivity
+          meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8449
+          meta_icon: https://vikunja.io/images/vikunja-logo.svg
+          meta_description: Todo List & Task Management
+          meta_publisher: Homelab

--- a/k8s/apps/vikunja/README.md
+++ b/k8s/apps/vikunja/README.md
@@ -22,8 +22,16 @@ This deployment consists of:
 ## Access
 
 - **Internal service DNS:** `vikunja.vikunja.svc.cluster.local`
-- **External access (Tailscale):** `http://<tailscale-ip>:30888`
-  - The service is exposed via NodePort 30888. Use Tailscale to route to the node's Tailscale address.
+- **NodePort:** `http://localhost:30888`
+- **Tailscale Serve:** `https://holdens-mac-mini.story-larch.ts.net:8449`
+
+One-time Tailscale Serve setup (run on the Mac mini):
+
+```bash
+tailscale serve --bg --https 8449 http://localhost:30888
+```
+
+Vikunja also appears as a bookmark in the Authentik portal under the **Productivity** group.
 
 ## Setup Steps
 


### PR DESCRIPTION
## Summary

Final polish for #86 — resolves the remaining ArgoCD OutOfSync and integrates Vikunja into the Authentik application portal.

### 1. Fix OutOfSync on ExternalSecret

The vikunja Application used `ServerSideApply=true` which no other app uses. With SSA, ArgoCD tracks ESO-injected default fields (`conversionStrategy`, `decodingStrategy`, `metadataPolicy`) as drift, causing permanent OutOfSync. Removing the option aligns with the pattern used by monitoring, authentik, and openclaw — all of which sync cleanly.

### 2. Add Authentik portal bookmark

Vikunja is now a bookmark application in the Authentik portal, matching the pattern for Infisical, OpenClaw, Trivy Dashboard, and Homelab Docs.

| Field | Value |
|---|---|
| Name | Vikunja |
| Group | Productivity |
| Tailscale Serve port | 8449 |
| URL | `https://holdens-mac-mini.story-larch.ts.net:8449` |
| Icon | `https://vikunja.io/images/vikunja-logo.svg` |

### Files changed

| File | Change |
|---|---|
| `vikunja-app.yaml` | Remove `ServerSideApply=true` |
| `blueprints-configmap.yaml` | Add Vikunja bookmark entry |
| Authentik `README.md` | Add Vikunja to bookmarks table |
| Vikunja `README.md` | Add Tailscale Serve access info |

## Test plan

- [ ] ArgoCD vikunja Application shows `Synced Healthy` (no more OutOfSync)
- [ ] Vikunja bookmark appears in Authentik portal under Productivity group
- [ ] After running `tailscale serve --bg --https 8449 http://localhost:30888` on Mac mini, Vikunja is accessible at `https://holdens-mac-mini.story-larch.ts.net:8449`


Made with [Cursor](https://cursor.com)