### PR TITLE
fix: update Vikunja Authentik bookmark icon

### DIFF
--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -64,6 +64,6 @@ data:
           name: Vikunja
           group: Productivity
           meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8449
-          meta_icon: https://vikunja.io/images/vikunja-logo.svg
+          meta_icon: https://avatars.githubusercontent.com/u/41270016?s=200&v=4
           meta_description: Todo List & Task Management
           meta_publisher: Homelab


### PR DESCRIPTION
## Summary

Update the Vikunja bookmark icon in the Authentik blueprints ConfigMap to use the Vikunja GitHub organization avatar.

## Test plan

- [ ] Authentik portal shows Vikunja with the correct icon


Made with [Cursor](https://cursor.com)