### PR TITLE
feat: integrate Vikunja OIDC authentication with Authentik (#86)

### DIFF
--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -59,6 +59,7 @@ Each service has a dedicated OIDC provider in Authentik with its own client ID a
 |---|---|---|---|
 | Grafana | `grafana` | `https://holdens-mac-mini.story-larch.ts.net:8444/login/generic_oauth` | Infisical: `GRAFANA_OAUTH_CLIENT_SECRET` |
 | ArgoCD | `argocd` | `https://holdens-mac-mini.story-larch.ts.net:8443/auth/callback` | Terraform: `argocd_oidc_client_secret` |
+| Vikunja | `vikunja` | `https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik` | Infisical: `VIKUNJA_OIDC_CLIENT_SECRET` |
 
 All providers use **RS256** signing (asymmetric keys). Scope mappings assigned: `openid`, `email`, `profile`.
 
@@ -70,6 +71,7 @@ All services enforce SSO-only access — local login forms are disabled:
 |---|---|
 | ArgoCD | `configs.cm.admin.enabled: false` — admin login disabled, RBAC default `role:admin` for all SSO users |
 | Grafana | `auth.disable_login_form: true`, `auto_login: true` — auto-redirects to Authentik |
+| Vikunja | `service.enableregistration: false` — local registration disabled, OIDC login available via config file |
 
 ## Configuration
 
@@ -98,6 +100,8 @@ Key settings:
 
 **ArgoCD** — configured in Terraform (`argocd.tf`) via `configs.cm.oidc.config`. Client secret stored in `argocd-secret` via Terraform `set_sensitive`. Requires `terraform apply` to update.
 
+**Vikunja** — configured via `config.yml` ConfigMap mounted at `/etc/vikunja/config.yml`. Client secret mounted from `vikunja-db-secret` ExternalSecret as a file at `/secrets/oidc-client-secret`. Provider created automatically via Authentik blueprint.
+
 ## Networking
 
 | Layer | Value |
@@ -122,7 +126,7 @@ tailscale serve --bg http://localhost:30500
 | Infisical | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8445` |
 | OpenClaw | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8447` |
 | Trivy Dashboard | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8448` |
-| Vikunja | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8449` |
+| Vikunja | OIDC (`auth.openid`) | `https://holdens-mac-mini.story-larch.ts.net:8449` |
 | Homelab Docs | Bookmark | `https://holdennguyen.github.io/homelab` |
 
 ## Adding a new Bookmark Application

--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -55,6 +55,23 @@ data:
           meta_icon: https://avatars.githubusercontent.com/u/252820863?s=48&v=4
           meta_description: AI Agent Gateway Console
           meta_publisher: Homelab
+      - model: authentik_providers_oauth2.oauth2provider
+        id: provider-vikunja
+        state: present
+        identifiers:
+          name: vikunja
+        attrs:
+          name: vikunja
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          client_type: confidential
+          client_id: vikunja
+          redirect_uris: |
+            https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
       - model: authentik_core.application
         id: app-vikunja
         state: present
@@ -62,8 +79,10 @@ data:
           slug: vikunja
         attrs:
           name: Vikunja
+          slug: vikunja
           group: Productivity
+          provider: !KeyOf provider-vikunja
           meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8449
-          meta_icon: https://vikunja.io/images/vikunja-logo.svg
+          meta_icon: https://avatars.githubusercontent.com/u/41270016?s=200&v=4
           meta_description: Todo List & Task Management
           meta_publisher: Homelab

--- a/k8s/apps/external-secrets/README.md
+++ b/k8s/apps/external-secrets/README.md
@@ -193,7 +193,7 @@ env:
 | `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password` | Authentik server + worker pods; embedded PostgreSQL |
 | `grafana-secret` | `monitoring` | `grafana-secret` | `admin-user`, `admin-password`, `oauth-client-id`, `oauth-client-secret` | Grafana admin login; Grafana OIDC via Authentik |
 | `openclaw-secret` | `openclaw` | `openclaw-secret` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN` | OpenClaw gateway env vars, agent git workflow |
-| `vikunja-db-secret` | `vikunja` | `vikunja-db-secret` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` | PostgreSQL + Vikunja database credentials |
+| `vikunja-db-secret` | `vikunja` | `vikunja-db-secret` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `OIDC_CLIENT_SECRET` | PostgreSQL + Vikunja database credentials; Authentik OIDC client secret |
 
 ## Security
 

--- a/k8s/apps/vikunja/README.md
+++ b/k8s/apps/vikunja/README.md
@@ -9,6 +9,7 @@ This deployment consists of:
 - Vikunja application server (Deployment)
 - Kubernetes Services for internal and external access
 - Prometheus ServiceMonitor for metrics collection
+- OIDC authentication via Authentik (SSO)
 
 ## Resources
 
@@ -44,21 +45,33 @@ Before the first sync, add the following secrets to Infisical under `homelab / p
 | `VIKUNJA_POSTGRES_USER` | PostgreSQL superuser username | `vikunja` |
 | `VIKUNJA_POSTGRES_PASSWORD` | Password for the PostgreSQL user | (random strong password) |
 | `VIKUNJA_POSTGRES_DB` | PostgreSQL database name | `vikunja` |
+| `VIKUNJA_OIDC_CLIENT_SECRET` | Authentik OAuth2 client secret for Vikunja | (copy from Authentik provider) |
 
 The External Secrets Operator will sync these into a `vikunja-db-secret` in the `vikunja` namespace. Both the PostgreSQL and Vikunja deployments share the same password key — no duplication needed.
 
-### 2. Authentik Bookmark
+### 2. Authentik OIDC Provider
 
-To add Vikunja as a bookmark in Authentik:
+Vikunja uses Authentik for SSO via OpenID Connect. The OAuth2 provider is created automatically via the Authentik blueprint in `k8s/apps/authentik/blueprints-configmap.yaml`.
 
-1. Log into Authentik.
-2. Go to **Applications** → **Add Application** → **Bookmark Application**.
-3. Configuration:
-   - **Name:** Vikunja
-   - **URL:** `http://<tailscale-ip>:30888` (or the Tailscale DNS name)
-   - **Group:** (assign as needed)
-   - **Icon:** (optional)
-4. Save. The application will appear in the user portal.
+After ArgoCD syncs the blueprint:
+
+1. Open Authentik Admin → **Applications** → **Providers** → **vikunja**
+2. Copy the **Client Secret** value
+3. Add it to Infisical as `VIKUNJA_OIDC_CLIENT_SECRET` under `homelab / prod /` (root path)
+4. Force an ExternalSecret re-sync:
+
+```bash
+kubectl annotate externalsecret vikunja-db-secret -n vikunja \
+  force-sync=$(date +%s) --overwrite
+```
+
+5. Restart the Vikunja deployment:
+
+```bash
+kubectl rollout restart deployment vikunja -n vikunja
+```
+
+The OIDC redirect URI is: `https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik`
 
 ### 3. ArgoCD Sync
 

--- a/k8s/apps/vikunja/external-secret.yaml
+++ b/k8s/apps/vikunja/external-secret.yaml
@@ -21,3 +21,6 @@ spec:
     - secretKey: POSTGRES_DB
       remoteRef:
         key: VIKUNJA_POSTGRES_DB
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: VIKUNJA_OIDC_CLIENT_SECRET

--- a/k8s/apps/vikunja/kustomization.yaml
+++ b/k8s/apps/vikunja/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - postgresql-service.yaml
   - postgresql-hba-config.yaml
   - postgresql-deployment.yaml
+  - vikunja-config.yaml
   - vikunja-pvc.yaml
   - vikunja-service.yaml
   - vikunja-deployment.yaml

--- a/k8s/apps/vikunja/vikunja-config.yaml
+++ b/k8s/apps/vikunja/vikunja-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vikunja-config
+  namespace: vikunja
+  labels:
+    app.kubernetes.io/name: vikunja
+    app.kubernetes.io/part-of: vikunja
+    app.kubernetes.io/managed-by: argocd
+data:
+  config.yml: |
+    service:
+      enableregistration: false
+    auth:
+      openid:
+        enabled: true
+        providers:
+          authentik:
+            name: "Login with Authentik"
+            authurl: https://holdens-mac-mini.story-larch.ts.net/application/o/vikunja/
+            clientid: vikunja
+            clientsecret:
+              file: /secrets/oidc-client-secret
+            scope: openid profile email

--- a/k8s/apps/vikunja/vikunja-deployment.yaml
+++ b/k8s/apps/vikunja/vikunja-deployment.yaml
@@ -51,7 +51,7 @@ spec:
                   name: vikunja-db-secret
                   key: POSTGRES_DB
             - name: VIKUNJA_SERVICE_PUBLICURL
-              value: "http://vikunja.vikunja.svc.cluster.local"
+              value: "https://holdens-mac-mini.story-larch.ts.net:8449"
             - name: VIKUNJA_SERVICE_TIMEZONE
               value: "UTC"
             - name: VIKUNJA_MAILER_ENABLED
@@ -80,6 +80,14 @@ spec:
           volumeMounts:
             - name: files
               mountPath: /app/files
+            - name: config
+              mountPath: /etc/vikunja/config.yml
+              subPath: config.yml
+              readOnly: true
+            - name: oidc-secret
+              mountPath: /secrets/oidc-client-secret
+              subPath: OIDC_CLIENT_SECRET
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -91,3 +99,12 @@ spec:
         - name: files
           persistentVolumeClaim:
             claimName: vikunja-files
+        - name: config
+          configMap:
+            name: vikunja-config
+        - name: oidc-secret
+          secret:
+            secretName: vikunja-db-secret
+            items:
+              - key: OIDC_CLIENT_SECRET
+                path: OIDC_CLIENT_SECRET


### PR DESCRIPTION
## Summary

- Add Authentik OAuth2 provider for Vikunja via blueprint (`blueprints-configmap.yaml`) with `client_id: vikunja`, RS256 signing, and redirect URI pointing to Tailscale endpoint
- Create Vikunja config ConfigMap (`vikunja-config.yaml`) with OIDC settings — `clientsecret` loaded from file mount at `/secrets/oidc-client-secret`
- Add `OIDC_CLIENT_SECRET` to ExternalSecret (maps to Infisical key `VIKUNJA_OIDC_CLIENT_SECRET`)
- Update deployment: mount config at `/etc/vikunja/config.yml`, mount OIDC secret as file, fix `VIKUNJA_SERVICE_PUBLICURL` to Tailscale URL
- Disable local registration (`service.enableregistration: false`) — first OIDC login creates admin user
- Update Authentik, ESO, and Vikunja READMEs

## Post-merge manual steps

After ArgoCD syncs the blueprint:

1. Open Authentik Admin → **Applications** → **Providers** → **vikunja**
2. Copy the auto-generated **Client Secret**
3. Add to Infisical as `VIKUNJA_OIDC_CLIENT_SECRET` under `homelab / prod /` (root path)
4. Force ExternalSecret re-sync: `kubectl annotate externalsecret vikunja-db-secret -n vikunja force-sync=$(date +%s) --overwrite`
5. Restart Vikunja: `kubectl rollout restart deployment vikunja -n vikunja`

## Test plan

- [ ] ArgoCD syncs `authentik-config` and `vikunja` applications without errors
- [ ] Authentik blueprint creates the OAuth2 provider with correct redirect URI
- [ ] `VIKUNJA_OIDC_CLIENT_SECRET` added to Infisical and synced to K8s Secret
- [ ] Vikunja login page shows "Login with Authentik" button
- [ ] OIDC flow completes: Authentik → consent → redirect back to Vikunja with valid session
- [ ] First SSO user becomes Vikunja admin


Made with [Cursor](https://cursor.com)