### PR TITLE
feat: manage Authentik OIDC provider via code with !Env blueprint tag (#86)

### DIFF
--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -1,6 +1,6 @@
 # Authentik (SSO / Identity Provider)
 
-Authentik provides **Single Sign-On (SSO)** for the homelab via **OpenID Connect (OIDC)**. One login, one password for Grafana and ArgoCD.
+Authentik provides **Single Sign-On (SSO)** for the homelab via **OpenID Connect (OIDC)**. One login, one password for Grafana, ArgoCD, and Vikunja.
 
 ## Access
 
@@ -24,11 +24,13 @@ flowchart TD
     subgraph services["Service OIDC integration"]
         Grafana["Grafana\nauth.generic_oauth"]
         ArgoCD["ArgoCD\noidc.config"]
+        Vikunja["Vikunja\nauth.openid"]
     end
 
     User["User"] -- "login" --> Server
     Server -- "OIDC token" --> Grafana
     Server -- "OIDC token" --> ArgoCD
+    Server -- "OIDC token" --> Vikunja
 ```
 
 ## Directory Contents
@@ -36,7 +38,8 @@ flowchart TD
 | File | Purpose |
 |------|---------|
 | `kustomization.yaml` | Lists resources for Kustomize/ArgoCD rendering |
-| `external-secret.yaml` | `ExternalSecret` that pulls Authentik secrets from Infisical → `authentik-secret` |
+| `external-secret.yaml` | `ExternalSecret` that pulls Authentik secrets + OIDC client secrets from Infisical → `authentik-secret` |
+| `blueprints-configmap.yaml` | Authentik Blueprint: bookmark apps + OIDC providers (applied automatically) |
 
 > **Note:** Authentik is deployed via the **Helm chart source** defined in `k8s/apps/argocd/applications/authentik-app.yaml`. This directory only contains the ExternalSecret that provides credentials to the Helm release. The `authentik-config` ArgoCD Application syncs this directory, while the `authentik` Application syncs the upstream Helm chart.
 
@@ -87,20 +90,21 @@ Key settings:
 
 ### Secrets in Infisical
 
-| Key | Purpose |
-|---|---|
-| `AUTHENTIK_SECRET_KEY` | Cookie signing and unique user IDs (never change after first install) |
-| `AUTHENTIK_BOOTSTRAP_PASSWORD` | Initial admin password |
-| `AUTHENTIK_BOOTSTRAP_TOKEN` | API token for automation |
-| `AUTHENTIK_POSTGRES_PASSWORD` | Embedded PostgreSQL password |
+| Key | Purpose | Consumed by |
+|---|---|---|
+| `AUTHENTIK_SECRET_KEY` | Cookie signing and unique user IDs (never change after first install) | Authentik server/worker |
+| `AUTHENTIK_BOOTSTRAP_PASSWORD` | Initial admin password | Authentik server |
+| `AUTHENTIK_BOOTSTRAP_TOKEN` | API token for automation | Authentik server |
+| `AUTHENTIK_POSTGRES_PASSWORD` | Embedded PostgreSQL password | Authentik server + PostgreSQL |
+| `VIKUNJA_OIDC_CLIENT_SECRET` | OAuth2 client secret for Vikunja provider | Authentik blueprint (`!Env`) + Vikunja config |
 
 ### OIDC integration per service
 
-**Grafana** — configured in Helm values (`monitoring-app.yaml`) via `grafana.ini.auth.generic_oauth`. Client secret mounted from `grafana-secret` ExternalSecret.
+**Grafana** — Provider created manually in Authentik UI. Client-side configured in Helm values (`monitoring-app.yaml`) via `grafana.ini.auth.generic_oauth`. Client secret mounted from `grafana-secret` ExternalSecret.
 
-**ArgoCD** — configured in Terraform (`argocd.tf`) via `configs.cm.oidc.config`. Client secret stored in `argocd-secret` via Terraform `set_sensitive`. Requires `terraform apply` to update.
+**ArgoCD** — Provider created manually in Authentik UI. Client-side configured in Terraform (`argocd.tf`) via `configs.cm.oidc.config`. Client secret stored in `argocd-secret` via Terraform `set_sensitive`. Requires `terraform apply` to update.
 
-**Vikunja** — configured via `config.yml` ConfigMap mounted at `/etc/vikunja/config.yml`. Client secret mounted from `vikunja-db-secret` ExternalSecret as a file at `/secrets/oidc-client-secret`. Provider created automatically via Authentik blueprint.
+**Vikunja** (reference implementation) — Fully code-managed. Provider created via Authentik Blueprint with `!Env` for the client secret. Client-side configured via `config.yml` ConfigMap mounted at `/etc/vikunja/config.yml`. Both Authentik and Vikunja read the same secret from Infisical — zero manual UI steps. See [Adding a new OIDC-protected service](#adding-a-new-oidc-protected-service) for the pattern.
 
 ## Networking
 
@@ -155,16 +159,148 @@ For services without native OIDC support, you can add them to the Authentik port
 
 ## Adding a new OIDC-protected service
 
-1. Create an OAuth2 provider in Authentik (UI or API): set client ID, secret, and redirect URI
-2. Create an Authentik Application and link it to the provider
-3. Assign scope mappings: `openid`, `email`, `profile`
-4. Store the client secret in Infisical
-5. Add the secret key to the service's ExternalSecret
-6. Configure the service's OIDC settings to point to Authentik's endpoints:
-   - Authorize: `https://holdens-mac-mini.story-larch.ts.net/application/o/authorize/`
-   - Token: `https://holdens-mac-mini.story-larch.ts.net/application/o/token/`
-   - Userinfo: `https://holdens-mac-mini.story-larch.ts.net/application/o/userinfo/`
-   - Discovery: `https://holdens-mac-mini.story-larch.ts.net/application/o/<slug>/.well-known/openid-configuration`
+This homelab uses a **fully code-managed** OIDC pattern. The Authentik OAuth2 provider, application, and client secret are all defined in git — no manual UI configuration required.
+
+### How it works
+
+```mermaid
+flowchart LR
+    Infisical["Infisical\nMY_SERVICE_OIDC_CLIENT_SECRET"]
+    AuthentikES["Authentik ExternalSecret\nauthentik-secret"]
+    ServiceES["Service ExternalSecret\nmy-service-secret"]
+    AuthentikPod["Authentik Pod\nenv: MY_SERVICE_OIDC_CLIENT_SECRET"]
+    Blueprint["Blueprint\n!Env MY_SERVICE_OIDC_CLIENT_SECRET"]
+    Provider["Authentik OAuth2 Provider\nclient_secret = env value"]
+    ServicePod["Service Pod\n/secrets/oidc-client-secret"]
+
+    Infisical --> AuthentikES --> AuthentikPod --> Blueprint --> Provider
+    Infisical --> ServiceES --> ServicePod
+```
+
+The secret is defined once in Infisical and flows to both sides:
+- **Authentik side:** ExternalSecret → `authentik-secret` K8s Secret → `envFrom` in pod → `!Env` in blueprint → OAuth2 provider `client_secret`
+- **Service side:** ExternalSecret → service K8s Secret → file mount → service OIDC config
+
+### Step-by-step checklist
+
+#### 1. Generate and store the client secret in Infisical
+
+Generate a random secret and add it to Infisical under `homelab / prod /` (root path):
+
+| Key | Example |
+|---|---|
+| `MY_SERVICE_OIDC_CLIENT_SECRET` | (random 64-char alphanumeric string) |
+
+#### 2. Add the secret to the Authentik ExternalSecret
+
+Edit `k8s/apps/authentik/external-secret.yaml`. Add a template data entry and a corresponding `data` entry:
+
+```yaml
+    template:
+      data:
+        # ... existing entries ...
+        MY_SERVICE_OIDC_CLIENT_SECRET: "{{ .myServiceOidcClientSecret }}"
+  data:
+    # ... existing entries ...
+    - secretKey: myServiceOidcClientSecret
+      remoteRef:
+        key: MY_SERVICE_OIDC_CLIENT_SECRET
+```
+
+This makes the secret available as an environment variable in all Authentik pods (via `global.envFrom` in the Helm values).
+
+#### 3. Add the OAuth2 provider and application to the blueprint
+
+Edit `k8s/apps/authentik/blueprints-configmap.yaml`. Add two entries — the provider first (so `!KeyOf` can reference it), then the application:
+
+```yaml
+      - model: authentik_providers_oauth2.oauth2provider
+        id: provider-my-service
+        state: present
+        identifiers:
+          name: my-service
+        attrs:
+          name: my-service
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          client_type: confidential
+          client_id: my-service
+          client_secret: !Env MY_SERVICE_OIDC_CLIENT_SECRET
+          redirect_uris: |
+            https://holdens-mac-mini.story-larch.ts.net:<port>/auth/callback
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+      - model: authentik_core.application
+        id: app-my-service
+        state: present
+        identifiers:
+          slug: my-service
+        attrs:
+          name: My Service
+          slug: my-service
+          group: Development
+          provider: !KeyOf provider-my-service
+          meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:<port>
+          meta_icon: https://url-to-icon.png
+          meta_description: Short description
+          meta_publisher: Homelab
+```
+
+Key blueprint tags:
+- `!Env MY_SERVICE_OIDC_CLIENT_SECRET` — reads from the pod environment (sourced from `authentik-secret`)
+- `!Find` — looks up existing Authentik objects by field (flows, keys, scope mappings)
+- `!KeyOf provider-my-service` — resolves to the primary key of the provider created earlier in the same blueprint
+
+#### 4. Add the secret to the service's ExternalSecret
+
+In the service's own `external-secret.yaml`, add a mapping for the same Infisical key:
+
+```yaml
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: MY_SERVICE_OIDC_CLIENT_SECRET
+```
+
+#### 5. Configure the service to use OIDC
+
+Mount the secret as a file or env var and configure the service's OIDC settings. Authentik endpoints are auto-discovered from:
+
+```
+https://holdens-mac-mini.story-larch.ts.net/application/o/<slug>/.well-known/openid-configuration
+```
+
+Standard Authentik endpoints:
+- **Authorize:** `https://holdens-mac-mini.story-larch.ts.net/application/o/authorize/`
+- **Token:** `https://holdens-mac-mini.story-larch.ts.net/application/o/token/`
+- **Userinfo:** `https://holdens-mac-mini.story-larch.ts.net/application/o/userinfo/`
+- **OIDC Discovery:** `https://holdens-mac-mini.story-larch.ts.net/application/o/<slug>/.well-known/openid-configuration`
+
+#### 6. Update documentation
+
+- Add the service to the [OIDC Providers](#oidc-providers) table above
+- Add the service to the [Authentication Model](#authentication-model) table
+- Add the service to the [Application Inventory](#application-inventory) table
+- Add the Infisical key to the [Secrets in Infisical](#secrets-in-infisical) table
+- Update the service's own README with OIDC setup notes
+- Update `k8s/apps/external-secrets/README.md` with the new secret key
+
+#### 7. Commit, merge, verify
+
+Push changes, create PR, merge to `main`. ArgoCD will sync both the `authentik-config` and service applications. Verify:
+
+```bash
+# Check Authentik blueprint applied
+kubectl logs -n authentik -l app.kubernetes.io/component=worker --tail=50 | grep -i blueprint
+
+# Check the provider exists
+kubectl exec -n authentik deploy/authentik-server -- \
+  ak test_provider my-service 2>/dev/null || echo "Use Authentik Admin UI to verify"
+
+# Check the service pod has the OIDC config
+kubectl logs -n <namespace> deploy/<service> --tail=20
+```
 
 ## Operational Commands
 
@@ -195,8 +331,11 @@ kubectl get application authentik authentik-config -n argocd
 |---|---|---|
 | "Login failed" on Grafana/ArgoCD | Redirect URI mismatch | Check the redirect URI in Authentik matches exactly (scheme, host, port, path) |
 | Authentik returns 502 | Server pod not ready | `kubectl get pods -n authentik` |
-| "Invalid client" error | Wrong client_id or secret | Verify the secret in Infisical matches what's in Authentik |
-| OIDC login button not showing | Config not applied | For ArgoCD: run `terraform apply`; for Grafana: wait for ArgoCD sync |
+| "Invalid client" error | Wrong client_id or secret | Verify the secret in Infisical matches what's in Authentik provider |
+| OIDC login button not showing | Config not applied | For ArgoCD: run `terraform apply`; for Grafana/Vikunja: wait for ArgoCD sync |
 | 403 `insufficient_scope` on userinfo | Provider missing scope mappings | Assign `openid`, `email`, `profile` scope mappings to the provider in Authentik |
 | ArgoCD `malformed jwt: unexpected algorithm HS256` | Provider using HS256 instead of RS256 | Update the provider's signing key to an RS256 keypair in Authentik |
 | ArgoCD shows no applications after SSO login | RBAC policy.default is empty | Set `configs.rbac.policy.default: role:admin` in Terraform |
+| Blueprint `!Env` returns empty | Secret not in `authentik-secret` K8s Secret | Check Authentik ExternalSecret template has the key; force re-sync and restart Authentik pods |
+| Provider created but client_secret wrong | Infisical value mismatch | Ensure the same Infisical key is used by both Authentik and service ExternalSecrets; force re-sync both |
+| Blueprint not applying after ConfigMap change | Worker hasn't picked up the new ConfigMap | Restart the Authentik worker: `kubectl rollout restart deployment authentik-worker -n authentik` |

--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -65,6 +65,7 @@ data:
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           client_type: confidential
           client_id: vikunja
+          client_secret: !Env VIKUNJA_OIDC_CLIENT_SECRET
           redirect_uris: |
             https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]

--- a/k8s/apps/authentik/external-secret.yaml
+++ b/k8s/apps/authentik/external-secret.yaml
@@ -21,6 +21,7 @@ spec:
         AUTHENTIK_BOOTSTRAP_TOKEN: "{{ .bootstrapToken }}"
         AUTHENTIK_POSTGRESQL__PASSWORD: "{{ .pgPassword }}"
         pg-password: "{{ .pgPassword }}"
+        VIKUNJA_OIDC_CLIENT_SECRET: "{{ .vikunjaOidcClientSecret }}"
   data:
     - secretKey: secretKey
       remoteRef:
@@ -34,3 +35,6 @@ spec:
     - secretKey: pgPassword
       remoteRef:
         key: AUTHENTIK_POSTGRES_PASSWORD
+    - secretKey: vikunjaOidcClientSecret
+      remoteRef:
+        key: VIKUNJA_OIDC_CLIENT_SECRET

--- a/k8s/apps/external-secrets/README.md
+++ b/k8s/apps/external-secrets/README.md
@@ -190,7 +190,7 @@ env:
 
 | ExternalSecret | Namespace | K8s Secret Created | Keys | Consumed By |
 |---|---|---|---|---|
-| `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password` | Authentik server + worker pods; embedded PostgreSQL |
+| `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password`, `VIKUNJA_OIDC_CLIENT_SECRET` | Authentik server + worker pods; embedded PostgreSQL; OIDC provider client secrets (via `!Env` in blueprints) |
 | `grafana-secret` | `monitoring` | `grafana-secret` | `admin-user`, `admin-password`, `oauth-client-id`, `oauth-client-secret` | Grafana admin login; Grafana OIDC via Authentik |
 | `openclaw-secret` | `openclaw` | `openclaw-secret` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN` | OpenClaw gateway env vars, agent git workflow |
 | `vikunja-db-secret` | `vikunja` | `vikunja-db-secret` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `OIDC_CLIENT_SECRET` | PostgreSQL + Vikunja database credentials; Authentik OIDC client secret |

--- a/k8s/apps/vikunja/README.md
+++ b/k8s/apps/vikunja/README.md
@@ -32,7 +32,7 @@ One-time Tailscale Serve setup (run on the Mac mini):
 tailscale serve --bg --https 8449 http://localhost:30888
 ```
 
-Vikunja also appears as a bookmark in the Authentik portal under the **Productivity** group.
+Vikunja is an OIDC-protected application in the Authentik portal under the **Productivity** group. Login is handled via Authentik SSO.
 
 ## Setup Steps
 
@@ -45,33 +45,33 @@ Before the first sync, add the following secrets to Infisical under `homelab / p
 | `VIKUNJA_POSTGRES_USER` | PostgreSQL superuser username | `vikunja` |
 | `VIKUNJA_POSTGRES_PASSWORD` | Password for the PostgreSQL user | (random strong password) |
 | `VIKUNJA_POSTGRES_DB` | PostgreSQL database name | `vikunja` |
-| `VIKUNJA_OIDC_CLIENT_SECRET` | Authentik OAuth2 client secret for Vikunja | (copy from Authentik provider) |
+| `VIKUNJA_OIDC_CLIENT_SECRET` | Authentik OAuth2 client secret for Vikunja | (random 64-char alphanumeric string) |
 
 The External Secrets Operator will sync these into a `vikunja-db-secret` in the `vikunja` namespace. Both the PostgreSQL and Vikunja deployments share the same password key — no duplication needed.
 
-### 2. Authentik OIDC Provider
+### 2. Authentik OIDC Provider (fully code-managed)
 
-Vikunja uses Authentik for SSO via OpenID Connect. The OAuth2 provider is created automatically via the Authentik blueprint in `k8s/apps/authentik/blueprints-configmap.yaml`.
+Vikunja uses Authentik for SSO via OpenID Connect. The entire OIDC integration is managed via code — no manual Authentik UI steps required.
 
-After ArgoCD syncs the blueprint:
+**How the secret flows:**
 
-1. Open Authentik Admin → **Applications** → **Providers** → **vikunja**
-2. Copy the **Client Secret** value
-3. Add it to Infisical as `VIKUNJA_OIDC_CLIENT_SECRET` under `homelab / prod /` (root path)
-4. Force an ExternalSecret re-sync:
+1. `VIKUNJA_OIDC_CLIENT_SECRET` is stored once in Infisical
+2. Authentik ExternalSecret (`k8s/apps/authentik/external-secret.yaml`) pulls it into `authentik-secret` → available as env var in Authentik pods via `envFrom`
+3. Authentik Blueprint (`k8s/apps/authentik/blueprints-configmap.yaml`) reads it via `!Env VIKUNJA_OIDC_CLIENT_SECRET` and sets it as the OAuth2 provider's `client_secret`
+4. Vikunja ExternalSecret (`k8s/apps/vikunja/external-secret.yaml`) also pulls it → mounted as a file at `/secrets/oidc-client-secret`
+5. Vikunja config (`k8s/apps/vikunja/vikunja-config.yaml`) references the file for `clientsecret`
 
-```bash
-kubectl annotate externalsecret vikunja-db-secret -n vikunja \
-  force-sync=$(date +%s) --overwrite
-```
+**OIDC details:**
 
-5. Restart the Vikunja deployment:
+| Setting | Value |
+|---|---|
+| Client ID | `vikunja` |
+| Redirect URI | `https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik` |
+| OIDC Discovery | `https://holdens-mac-mini.story-larch.ts.net/application/o/vikunja/.well-known/openid-configuration` |
+| Scopes | `openid profile email` |
+| Signing algorithm | RS256 |
 
-```bash
-kubectl rollout restart deployment vikunja -n vikunja
-```
-
-The OIDC redirect URI is: `https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik`
+For the general pattern, see [Adding a new OIDC-protected service](../authentik/README.md#adding-a-new-oidc-protected-service).
 
 ### 3. ArgoCD Sync
 
@@ -143,9 +143,13 @@ Note: Changing the PostgreSQL `POSTGRES_PASSWORD` requires a database password u
 - **Cannot connect to database:** Verify the `vikunja-db-secret` exists and has correct keys. Ensure PostgreSQL pod is Ready.
 - **No metrics in Prometheus:** Confirm the ServiceMonitor has been synced and the `vikunja` Service has the correct labels.
 - **External access not working:** Ensure Tailscale routing to the node and that the NodePort is within the allowed range (30000-32767). Check service `type: NodePort` and `nodePort: 30888`.
+- **OIDC "Login with Authentik" not showing:** Check that `vikunja-config` ConfigMap is mounted at `/etc/vikunja/config.yml` and the `auth.openid.enabled` is `true`. Verify the pod has restarted after ConfigMap changes.
+- **OIDC "invalid client" error:** Verify `VIKUNJA_OIDC_CLIENT_SECRET` in Infisical matches what the Authentik provider has. Force re-sync both ExternalSecrets (`authentik-secret` and `vikunja-db-secret`) and restart both pods.
 
 ## References
 
 - [Vikunja Documentation](https://vikunja.io)
+- [Vikunja OpenID Connect](https://vikunja.io/docs/openid)
 - [Vikunja GitHub](https://github.com/go-vikunja/vikunja)
-- [Authentik Bookmark Applications](https://docs.goauthentik.io/docs/Applications/Bookmark)
+- [Authentik Blueprints — YAML Tags](https://docs.goauthentik.io/customize/blueprints/v1/tags)
+- [Authentik OIDC Provider](https://docs.goauthentik.io/docs/add-secure-apps/providers/oauth2/)


### PR DESCRIPTION
## Summary

- Add `VIKUNJA_OIDC_CLIENT_SECRET` to the Authentik ExternalSecret template — the Helm chart's `global.envFrom` makes it available as an env var in all Authentik pods
- Add `client_secret: !Env VIKUNJA_OIDC_CLIENT_SECRET` to the blueprint OAuth2 provider — Authentik reads the secret from its own environment, eliminating manual UI configuration
- Both Authentik (provider-side) and Vikunja (client-side) now read the same Infisical key — single source of truth, zero manual steps
- Rewrite Authentik README "Adding a new OIDC-protected service" section with a comprehensive code-driven guide including architecture diagram, step-by-step checklist, and blueprint tag reference
- Update Vikunja README to reflect the fully automated OIDC flow
- Update ESO README to reflect `authentik-secret` now carries OIDC client secrets
- Add new troubleshooting entries for blueprint `!Env`, client secret mismatch, and ConfigMap propagation

## Pre-requisites (Infisical)

Before merging, ensure `VIKUNJA_OIDC_CLIENT_SECRET` exists in Infisical under `homelab / prod /` (root path) with a strong random value. This same value will be used by both the Authentik provider and Vikunja client.

## Test plan

- [ ] `authentik-secret` K8s Secret contains the `VIKUNJA_OIDC_CLIENT_SECRET` key after ESO sync
- [ ] Authentik worker logs show blueprint applied without errors
- [ ] Authentik Admin → Providers → `vikunja` shows the correct `client_secret` (matches Infisical value)
- [ ] Vikunja login page shows "Login with Authentik" button
- [ ] OIDC flow completes: Authentik → consent → redirect back to Vikunja with valid session


Made with [Cursor](https://cursor.com)