### PR TITLE
fix: manage OIDC provider via Authentik UI, not blueprint (#86)

### DIFF
--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -38,8 +38,8 @@ flowchart TD
 | File | Purpose |
 |------|---------|
 | `kustomization.yaml` | Lists resources for Kustomize/ArgoCD rendering |
-| `external-secret.yaml` | `ExternalSecret` that pulls Authentik secrets + OIDC client secrets from Infisical → `authentik-secret` |
-| `blueprints-configmap.yaml` | Authentik Blueprint: bookmark apps + OIDC providers (applied automatically) |
+| `external-secret.yaml` | `ExternalSecret` that pulls Authentik secrets from Infisical → `authentik-secret` |
+| `blueprints-configmap.yaml` | Authentik Blueprint: application entries for portal (bookmarks + OIDC apps) |
 
 > **Note:** Authentik is deployed via the **Helm chart source** defined in `k8s/apps/argocd/applications/authentik-app.yaml`. This directory only contains the ExternalSecret that provides credentials to the Helm release. The `authentik-config` ArgoCD Application syncs this directory, while the `authentik` Application syncs the upstream Helm chart.
 
@@ -96,15 +96,16 @@ Key settings:
 | `AUTHENTIK_BOOTSTRAP_PASSWORD` | Initial admin password | Authentik server |
 | `AUTHENTIK_BOOTSTRAP_TOKEN` | API token for automation | Authentik server |
 | `AUTHENTIK_POSTGRES_PASSWORD` | Embedded PostgreSQL password | Authentik server + PostgreSQL |
-| `VIKUNJA_OIDC_CLIENT_SECRET` | OAuth2 client secret for Vikunja provider | Authentik blueprint (`!Env`) + Vikunja config |
 
 ### OIDC integration per service
 
-**Grafana** — Provider created manually in Authentik UI. Client-side configured in Helm values (`monitoring-app.yaml`) via `grafana.ini.auth.generic_oauth`. Client secret mounted from `grafana-secret` ExternalSecret.
+All OIDC providers are created via the Authentik Admin UI. The blueprint only manages application metadata (name, icon, group, launch URL). Provider linking is done manually in the UI after creation.
 
-**ArgoCD** — Provider created manually in Authentik UI. Client-side configured in Terraform (`argocd.tf`) via `configs.cm.oidc.config`. Client secret stored in `argocd-secret` via Terraform `set_sensitive`. Requires `terraform apply` to update.
+**Grafana** — Client-side configured in Helm values (`monitoring-app.yaml`) via `grafana.ini.auth.generic_oauth`. Client secret mounted from `grafana-secret` ExternalSecret.
 
-**Vikunja** (reference implementation) — Fully code-managed. Provider created via Authentik Blueprint with `!Env` for the client secret. Client-side configured via `config.yml` ConfigMap mounted at `/etc/vikunja/config.yml`. Both Authentik and Vikunja read the same secret from Infisical — zero manual UI steps. See [Adding a new OIDC-protected service](#adding-a-new-oidc-protected-service) for the pattern.
+**ArgoCD** — Client-side configured in Terraform (`argocd.tf`) via `configs.cm.oidc.config`. Client secret stored in `argocd-secret` via Terraform `set_sensitive`. Requires `terraform apply` to update.
+
+**Vikunja** — Client-side configured via `config.yml` ConfigMap mounted at `/etc/vikunja/config.yml`. Client secret mounted from `vikunja-db-secret` ExternalSecret as a file at `/secrets/oidc-client-secret`.
 
 ## Networking
 
@@ -159,27 +160,21 @@ For services without native OIDC support, you can add them to the Authentik port
 
 ## Adding a new OIDC-protected service
 
-This homelab uses a **fully code-managed** OIDC pattern. The Authentik OAuth2 provider, application, and client secret are all defined in git — no manual UI configuration required.
+OIDC providers are created in the **Authentik Admin UI**, consistent with how ArgoCD and Grafana are set up. The client secret is stored in Infisical and delivered to the service via ExternalSecret. The blueprint manages only application metadata (name, icon, group).
 
 ### How it works
 
 ```mermaid
 flowchart LR
     Infisical["Infisical\nMY_SERVICE_OIDC_CLIENT_SECRET"]
-    AuthentikES["Authentik ExternalSecret\nauthentik-secret"]
-    ServiceES["Service ExternalSecret\nmy-service-secret"]
-    AuthentikPod["Authentik Pod\nenv: MY_SERVICE_OIDC_CLIENT_SECRET"]
-    Blueprint["Blueprint\n!Env MY_SERVICE_OIDC_CLIENT_SECRET"]
-    Provider["Authentik OAuth2 Provider\nclient_secret = env value"]
-    ServicePod["Service Pod\n/secrets/oidc-client-secret"]
+    ServiceES["Service ExternalSecret"]
+    ServicePod["Service Pod\nclient secret via env/file"]
+    AuthentikUI["Authentik Admin UI\nOAuth2 Provider\n(client_secret = same value)"]
+    Blueprint["Blueprint\nApplication metadata only"]
 
-    Infisical --> AuthentikES --> AuthentikPod --> Blueprint --> Provider
     Infisical --> ServiceES --> ServicePod
+    AuthentikUI -- "provider linked to app" --> Blueprint
 ```
-
-The secret is defined once in Infisical and flows to both sides:
-- **Authentik side:** ExternalSecret → `authentik-secret` K8s Secret → `envFrom` in pod → `!Env` in blueprint → OAuth2 provider `client_secret`
-- **Service side:** ExternalSecret → service K8s Secret → file mount → service OIDC config
 
 ### Step-by-step checklist
 
@@ -191,71 +186,35 @@ Generate a random secret and add it to Infisical under `homelab / prod /` (root 
 |---|---|
 | `MY_SERVICE_OIDC_CLIENT_SECRET` | (random 64-char alphanumeric string) |
 
-#### 2. Add the secret to the Authentik ExternalSecret
+#### 2. Create the OAuth2 provider in Authentik UI
 
-Edit `k8s/apps/authentik/external-secret.yaml`. Add a template data entry and a corresponding `data` entry:
+1. Open Authentik Admin → **Applications** → **Providers** → **Create**
+2. Select **OAuth2/OpenID Provider**
+3. Configure:
 
-```yaml
-    template:
-      data:
-        # ... existing entries ...
-        MY_SERVICE_OIDC_CLIENT_SECRET: "{{ .myServiceOidcClientSecret }}"
-  data:
-    # ... existing entries ...
-    - secretKey: myServiceOidcClientSecret
-      remoteRef:
-        key: MY_SERVICE_OIDC_CLIENT_SECRET
-```
+| Field | Value |
+|---|---|
+| Name | `my-service` |
+| Authentication flow | (leave default) |
+| Authorization flow | `default-provider-authorization-implicit-consent` |
+| Client type | Confidential |
+| Client ID | `my-service` |
+| Client Secret | Paste the same value stored in Infisical |
+| Redirect URIs | `https://holdens-mac-mini.story-larch.ts.net:<port>/auth/callback` |
+| Signing Key | `authentik Self-signed Certificate` |
+| Scopes | `openid`, `email`, `profile` |
 
-This makes the secret available as an environment variable in all Authentik pods (via `global.envFrom` in the Helm values).
+4. Save the provider.
 
-#### 3. Add the OAuth2 provider and application to the blueprint
+#### 3. Link the provider to the application
 
-Edit `k8s/apps/authentik/blueprints-configmap.yaml`. Add two entries — the provider first (so `!KeyOf` can reference it), then the application:
+In Authentik Admin → **Applications** → select the application (created by blueprint) → **Edit** → set **Provider** to the newly created provider → Save.
 
-```yaml
-      - model: authentik_providers_oauth2.oauth2provider
-        id: provider-my-service
-        state: present
-        identifiers:
-          name: my-service
-        attrs:
-          name: my-service
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
-          client_type: confidential
-          client_id: my-service
-          client_secret: !Env MY_SERVICE_OIDC_CLIENT_SECRET
-          redirect_uris: |
-            https://holdens-mac-mini.story-larch.ts.net:<port>/auth/callback
-          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
-          property_mappings:
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
-      - model: authentik_core.application
-        id: app-my-service
-        state: present
-        identifiers:
-          slug: my-service
-        attrs:
-          name: My Service
-          slug: my-service
-          group: Development
-          provider: !KeyOf provider-my-service
-          meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:<port>
-          meta_icon: https://url-to-icon.png
-          meta_description: Short description
-          meta_publisher: Homelab
-```
-
-Key blueprint tags:
-- `!Env MY_SERVICE_OIDC_CLIENT_SECRET` — reads from the pod environment (sourced from `authentik-secret`)
-- `!Find` — looks up existing Authentik objects by field (flows, keys, scope mappings)
-- `!KeyOf provider-my-service` — resolves to the primary key of the provider created earlier in the same blueprint
+If the application doesn't exist yet, add it to the blueprint first (see [Adding a new Bookmark Application](#adding-a-new-bookmark-application)), merge, wait for sync, then link.
 
 #### 4. Add the secret to the service's ExternalSecret
 
-In the service's own `external-secret.yaml`, add a mapping for the same Infisical key:
+In the service's own `external-secret.yaml`, add a mapping for the Infisical key:
 
 ```yaml
     - secretKey: OIDC_CLIENT_SECRET
@@ -279,28 +238,19 @@ Standard Authentik endpoints:
 
 #### 6. Update documentation
 
-- Add the service to the [OIDC Providers](#oidc-providers) table above
+- Add the service to the [OIDC Providers](#oidc-providers) table
 - Add the service to the [Authentication Model](#authentication-model) table
 - Add the service to the [Application Inventory](#application-inventory) table
-- Add the Infisical key to the [Secrets in Infisical](#secrets-in-infisical) table
 - Update the service's own README with OIDC setup notes
 - Update `k8s/apps/external-secrets/README.md` with the new secret key
 
 #### 7. Commit, merge, verify
 
-Push changes, create PR, merge to `main`. ArgoCD will sync both the `authentik-config` and service applications. Verify:
+Push changes, create PR, merge to `main`. ArgoCD will sync the service application. After sync:
 
-```bash
-# Check Authentik blueprint applied
-kubectl logs -n authentik -l app.kubernetes.io/component=worker --tail=50 | grep -i blueprint
-
-# Check the provider exists
-kubectl exec -n authentik deploy/authentik-server -- \
-  ak test_provider my-service 2>/dev/null || echo "Use Authentik Admin UI to verify"
-
-# Check the service pod has the OIDC config
-kubectl logs -n <namespace> deploy/<service> --tail=20
-```
+1. Restart the service pod to pick up the new OIDC config
+2. Verify the OIDC discovery URL resolves: `curl -sk https://holdens-mac-mini.story-larch.ts.net/application/o/<slug>/.well-known/openid-configuration`
+3. Test login via the service's OIDC button
 
 ## Operational Commands
 
@@ -336,6 +286,5 @@ kubectl get application authentik authentik-config -n argocd
 | 403 `insufficient_scope` on userinfo | Provider missing scope mappings | Assign `openid`, `email`, `profile` scope mappings to the provider in Authentik |
 | ArgoCD `malformed jwt: unexpected algorithm HS256` | Provider using HS256 instead of RS256 | Update the provider's signing key to an RS256 keypair in Authentik |
 | ArgoCD shows no applications after SSO login | RBAC policy.default is empty | Set `configs.rbac.policy.default: role:admin` in Terraform |
-| Blueprint `!Env` returns empty | Secret not in `authentik-secret` K8s Secret | Check Authentik ExternalSecret template has the key; force re-sync and restart Authentik pods |
-| Provider created but client_secret wrong | Infisical value mismatch | Ensure the same Infisical key is used by both Authentik and service ExternalSecrets; force re-sync both |
+| Provider client_secret mismatch | Infisical value doesn't match Authentik UI | Update the provider's client secret in Authentik UI to match the Infisical value; restart service pod |
 | Blueprint not applying after ConfigMap change | Worker hasn't picked up the new ConfigMap | Restart the Authentik worker: `kubectl rollout restart deployment authentik-worker -n authentik` |

--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -55,24 +55,6 @@ data:
           meta_icon: https://avatars.githubusercontent.com/u/252820863?s=48&v=4
           meta_description: AI Agent Gateway Console
           meta_publisher: Homelab
-      - model: authentik_providers_oauth2.oauth2provider
-        id: provider-vikunja
-        state: present
-        identifiers:
-          name: vikunja
-        attrs:
-          name: vikunja
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
-          client_type: confidential
-          client_id: vikunja
-          client_secret: !Env VIKUNJA_OIDC_CLIENT_SECRET
-          redirect_uris: |
-            https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik
-          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
-          property_mappings:
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
       - model: authentik_core.application
         id: app-vikunja
         state: present
@@ -82,7 +64,6 @@ data:
           name: Vikunja
           slug: vikunja
           group: Productivity
-          provider: !KeyOf provider-vikunja
           meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8449
           meta_icon: https://avatars.githubusercontent.com/u/41270016?s=200&v=4
           meta_description: Todo List & Task Management

--- a/k8s/apps/authentik/external-secret.yaml
+++ b/k8s/apps/authentik/external-secret.yaml
@@ -21,7 +21,6 @@ spec:
         AUTHENTIK_BOOTSTRAP_TOKEN: "{{ .bootstrapToken }}"
         AUTHENTIK_POSTGRESQL__PASSWORD: "{{ .pgPassword }}"
         pg-password: "{{ .pgPassword }}"
-        VIKUNJA_OIDC_CLIENT_SECRET: "{{ .vikunjaOidcClientSecret }}"
   data:
     - secretKey: secretKey
       remoteRef:
@@ -35,6 +34,3 @@ spec:
     - secretKey: pgPassword
       remoteRef:
         key: AUTHENTIK_POSTGRES_PASSWORD
-    - secretKey: vikunjaOidcClientSecret
-      remoteRef:
-        key: VIKUNJA_OIDC_CLIENT_SECRET

--- a/k8s/apps/external-secrets/README.md
+++ b/k8s/apps/external-secrets/README.md
@@ -190,7 +190,7 @@ env:
 
 | ExternalSecret | Namespace | K8s Secret Created | Keys | Consumed By |
 |---|---|---|---|---|
-| `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password`, `VIKUNJA_OIDC_CLIENT_SECRET` | Authentik server + worker pods; embedded PostgreSQL; OIDC provider client secrets (via `!Env` in blueprints) |
+| `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password` | Authentik server + worker pods; embedded PostgreSQL |
 | `grafana-secret` | `monitoring` | `grafana-secret` | `admin-user`, `admin-password`, `oauth-client-id`, `oauth-client-secret` | Grafana admin login; Grafana OIDC via Authentik |
 | `openclaw-secret` | `openclaw` | `openclaw-secret` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN` | OpenClaw gateway env vars, agent git workflow |
 | `vikunja-db-secret` | `vikunja` | `vikunja-db-secret` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `OIDC_CLIENT_SECRET` | PostgreSQL + Vikunja database credentials; Authentik OIDC client secret |

--- a/k8s/apps/vikunja/README.md
+++ b/k8s/apps/vikunja/README.md
@@ -49,17 +49,31 @@ Before the first sync, add the following secrets to Infisical under `homelab / p
 
 The External Secrets Operator will sync these into a `vikunja-db-secret` in the `vikunja` namespace. Both the PostgreSQL and Vikunja deployments share the same password key — no duplication needed.
 
-### 2. Authentik OIDC Provider (fully code-managed)
+### 2. Create Authentik OIDC Provider
 
-Vikunja uses Authentik for SSO via OpenID Connect. The entire OIDC integration is managed via code — no manual Authentik UI steps required.
+Vikunja uses Authentik for SSO via OpenID Connect. The provider is created in the Authentik Admin UI (same pattern as ArgoCD and Grafana).
 
-**How the secret flows:**
+1. Open Authentik Admin → **Applications** → **Providers** → **Create** → **OAuth2/OpenID Provider**
+2. Configure:
 
-1. `VIKUNJA_OIDC_CLIENT_SECRET` is stored once in Infisical
-2. Authentik ExternalSecret (`k8s/apps/authentik/external-secret.yaml`) pulls it into `authentik-secret` → available as env var in Authentik pods via `envFrom`
-3. Authentik Blueprint (`k8s/apps/authentik/blueprints-configmap.yaml`) reads it via `!Env VIKUNJA_OIDC_CLIENT_SECRET` and sets it as the OAuth2 provider's `client_secret`
-4. Vikunja ExternalSecret (`k8s/apps/vikunja/external-secret.yaml`) also pulls it → mounted as a file at `/secrets/oidc-client-secret`
-5. Vikunja config (`k8s/apps/vikunja/vikunja-config.yaml`) references the file for `clientsecret`
+| Field | Value |
+|---|---|
+| Name | `vikunja` |
+| Authorization flow | `default-provider-authorization-implicit-consent` |
+| Client type | Confidential |
+| Client ID | `vikunja` |
+| Client Secret | Paste the value from Infisical key `VIKUNJA_OIDC_CLIENT_SECRET` |
+| Redirect URIs | `https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik` |
+| Signing Key | `authentik Self-signed Certificate` |
+| Scopes | `openid`, `email`, `profile` |
+
+3. Save the provider.
+4. Go to **Applications** → **vikunja** → **Edit** → set **Provider** to `vikunja` → Save.
+5. Restart the Vikunja deployment to re-discover the OIDC provider:
+
+```bash
+kubectl rollout restart deployment vikunja -n vikunja
+```
 
 **OIDC details:**
 
@@ -70,6 +84,8 @@ Vikunja uses Authentik for SSO via OpenID Connect. The entire OIDC integration i
 | OIDC Discovery | `https://holdens-mac-mini.story-larch.ts.net/application/o/vikunja/.well-known/openid-configuration` |
 | Scopes | `openid profile email` |
 | Signing algorithm | RS256 |
+
+The client secret flows from Infisical → Vikunja ExternalSecret → K8s Secret → file mount at `/secrets/oidc-client-secret` → referenced by `vikunja-config.yaml`.
 
 For the general pattern, see [Adding a new OIDC-protected service](../authentik/README.md#adding-a-new-oidc-protected-service).
 


### PR DESCRIPTION
## Summary

- Remove `authentik_providers_oauth2.oauth2provider` and `!KeyOf` entries from the blueprint — the blueprint `!Find` for scope mappings is incompatible with Authentik 2025.12.4, causing silent failures (`status: error`)
- Remove `VIKUNJA_OIDC_CLIENT_SECRET` from Authentik ExternalSecret — not needed since provider is created in UI, not via `!Env`
- Revert blueprint to simple application metadata entry (consistent with other bookmark apps)
- Rewrite "Adding a new OIDC-protected service" guide to match the proven pattern used by ArgoCD and Grafana: provider created in Authentik Admin UI, client secret stored in Infisical, delivered to service via ExternalSecret
- Update Vikunja README with step-by-step Authentik UI provider setup instructions

## Post-merge manual steps

1. Wait for ArgoCD to sync `authentik-config` (fixes blueprint error status)
2. Create OAuth2 provider in Authentik UI per the Vikunja README instructions
3. Link the provider to the Vikunja application in Authentik UI
4. Restart Vikunja: `kubectl rollout restart deployment vikunja -n vikunja`

## Test plan

- [ ] Blueprint `bookmarks.yaml` status returns to `successful` after sync
- [ ] OIDC discovery URL resolves: `curl -sk https://holdens-mac-mini.story-larch.ts.net/application/o/vikunja/.well-known/openid-configuration`
- [ ] Vikunja login page shows "Login with Authentik" button
- [ ] OIDC flow completes: Authentik → consent → redirect back to Vikunja


Made with [Cursor](https://cursor.com)