### PR TITLE
fix: use Authentik API for OIDC provider creation, remove broken blueprint (#86)

### DIFF
--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -38,8 +38,8 @@ flowchart TD
 | File | Purpose |
 |------|---------|
 | `kustomization.yaml` | Lists resources for Kustomize/ArgoCD rendering |
-| `external-secret.yaml` | `ExternalSecret` that pulls Authentik secrets + OIDC client secrets from Infisical → `authentik-secret` |
-| `blueprints-configmap.yaml` | Authentik Blueprint: bookmark apps + OIDC providers (applied automatically) |
+| `external-secret.yaml` | `ExternalSecret` that pulls Authentik secrets from Infisical → `authentik-secret` |
+| `blueprints-configmap.yaml` | Authentik Blueprint: application entries for the portal (bookmarks + metadata) |
 
 > **Note:** Authentik is deployed via the **Helm chart source** defined in `k8s/apps/argocd/applications/authentik-app.yaml`. This directory only contains the ExternalSecret that provides credentials to the Helm release. The `authentik-config` ArgoCD Application syncs this directory, while the `authentik` Application syncs the upstream Helm chart.
 
@@ -96,15 +96,16 @@ Key settings:
 | `AUTHENTIK_BOOTSTRAP_PASSWORD` | Initial admin password | Authentik server |
 | `AUTHENTIK_BOOTSTRAP_TOKEN` | API token for automation | Authentik server |
 | `AUTHENTIK_POSTGRES_PASSWORD` | Embedded PostgreSQL password | Authentik server + PostgreSQL |
-| `VIKUNJA_OIDC_CLIENT_SECRET` | OAuth2 client secret for Vikunja provider | Authentik blueprint (`!Env`) + Vikunja config |
 
 ### OIDC integration per service
 
-**Grafana** — Provider created manually in Authentik UI. Client-side configured in Helm values (`monitoring-app.yaml`) via `grafana.ini.auth.generic_oauth`. Client secret mounted from `grafana-secret` ExternalSecret.
+All OIDC providers are created via the Authentik API using the bootstrap token. The blueprint manages only application metadata (name, icon, group, launch URL). Provider linking is done via API after creation.
 
-**ArgoCD** — Provider created manually in Authentik UI. Client-side configured in Terraform (`argocd.tf`) via `configs.cm.oidc.config`. Client secret stored in `argocd-secret` via Terraform `set_sensitive`. Requires `terraform apply` to update.
+**Grafana** — Client-side configured in Helm values (`monitoring-app.yaml`) via `grafana.ini.auth.generic_oauth`. Client secret mounted from `grafana-secret` ExternalSecret.
 
-**Vikunja** (reference implementation) — Fully code-managed. Provider created via Authentik Blueprint with `!Env` for the client secret. Client-side configured via `config.yml` ConfigMap mounted at `/etc/vikunja/config.yml`. Both Authentik and Vikunja read the same secret from Infisical — zero manual UI steps. See [Adding a new OIDC-protected service](#adding-a-new-oidc-protected-service) for the pattern.
+**ArgoCD** — Client-side configured in Terraform (`argocd.tf`) via `configs.cm.oidc.config`. Client secret stored in `argocd-secret` via Terraform `set_sensitive`. Requires `terraform apply` to update.
+
+**Vikunja** — Client-side configured via `config.yml` ConfigMap mounted at `/etc/vikunja/config.yml`. Client secret mounted from `vikunja-db-secret` ExternalSecret as a file at `/secrets/oidc-client-secret`.
 
 ## Networking
 
@@ -159,27 +160,21 @@ For services without native OIDC support, you can add them to the Authentik port
 
 ## Adding a new OIDC-protected service
 
-This homelab uses a **fully code-managed** OIDC pattern. The Authentik OAuth2 provider, application, and client secret are all defined in git — no manual UI configuration required.
+OIDC providers are created via the **Authentik API** using the bootstrap token — same one-time bootstrap pattern for all services. The blueprint manages only application metadata (name, icon, group). The client secret is stored once in Infisical and delivered to the service via ExternalSecret.
 
 ### How it works
 
 ```mermaid
 flowchart LR
     Infisical["Infisical\nMY_SERVICE_OIDC_CLIENT_SECRET"]
-    AuthentikES["Authentik ExternalSecret\nauthentik-secret"]
-    ServiceES["Service ExternalSecret\nmy-service-secret"]
-    AuthentikPod["Authentik Pod\nenv: MY_SERVICE_OIDC_CLIENT_SECRET"]
-    Blueprint["Blueprint\n!Env MY_SERVICE_OIDC_CLIENT_SECRET"]
-    Provider["Authentik OAuth2 Provider\nclient_secret = env value"]
-    ServicePod["Service Pod\n/secrets/oidc-client-secret"]
+    ServiceES["Service ExternalSecret"]
+    ServicePod["Service Pod\nclient secret via env/file"]
+    API["Authentik API\nOAuth2 Provider\n(bootstrap token + same secret)"]
+    Blueprint["Blueprint\nApplication metadata only"]
 
-    Infisical --> AuthentikES --> AuthentikPod --> Blueprint --> Provider
     Infisical --> ServiceES --> ServicePod
+    API -- "provider linked to app" --> Blueprint
 ```
-
-The secret is defined once in Infisical and flows to both sides:
-- **Authentik side:** ExternalSecret → `authentik-secret` K8s Secret → `envFrom` in pod → `!Env` in blueprint → OAuth2 provider `client_secret`
-- **Service side:** ExternalSecret → service K8s Secret → file mount → service OIDC config
 
 ### Step-by-step checklist
 
@@ -191,77 +186,77 @@ Generate a random secret and add it to Infisical under `homelab / prod /` (root 
 |---|---|
 | `MY_SERVICE_OIDC_CLIENT_SECRET` | (random 64-char alphanumeric string) |
 
-#### 2. Add the secret to the Authentik ExternalSecret
+#### 2. Add the application bookmark to the blueprint
 
-Edit `k8s/apps/authentik/external-secret.yaml`. Add a template data entry and a corresponding `data` entry:
+Edit `k8s/apps/authentik/blueprints-configmap.yaml` and add an entry (see [Adding a new Bookmark Application](#adding-a-new-bookmark-application)). Commit and merge so the application exists before linking.
 
-```yaml
-    template:
-      data:
-        # ... existing entries ...
-        MY_SERVICE_OIDC_CLIENT_SECRET: "{{ .myServiceOidcClientSecret }}"
-  data:
-    # ... existing entries ...
-    - secretKey: myServiceOidcClientSecret
-      remoteRef:
-        key: MY_SERVICE_OIDC_CLIENT_SECRET
-```
+#### 3. Add the secret to the service's ExternalSecret
 
-This makes the secret available as an environment variable in all Authentik pods (via `global.envFrom` in the Helm values).
-
-#### 3. Add the OAuth2 provider and application to the blueprint
-
-Edit `k8s/apps/authentik/blueprints-configmap.yaml`. Add two entries — the provider first (so `!KeyOf` can reference it), then the application:
-
-```yaml
-      - model: authentik_providers_oauth2.oauth2provider
-        id: provider-my-service
-        state: present
-        identifiers:
-          name: my-service
-        attrs:
-          name: my-service
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
-          client_type: confidential
-          client_id: my-service
-          client_secret: !Env MY_SERVICE_OIDC_CLIENT_SECRET
-          redirect_uris: |
-            https://holdens-mac-mini.story-larch.ts.net:<port>/auth/callback
-          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
-          property_mappings:
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
-      - model: authentik_core.application
-        id: app-my-service
-        state: present
-        identifiers:
-          slug: my-service
-        attrs:
-          name: My Service
-          slug: my-service
-          group: Development
-          provider: !KeyOf provider-my-service
-          meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:<port>
-          meta_icon: https://url-to-icon.png
-          meta_description: Short description
-          meta_publisher: Homelab
-```
-
-Key blueprint tags:
-- `!Env MY_SERVICE_OIDC_CLIENT_SECRET` — reads from the pod environment (sourced from `authentik-secret`)
-- `!Find` — looks up existing Authentik objects by field (flows, keys, scope mappings)
-- `!KeyOf provider-my-service` — resolves to the primary key of the provider created earlier in the same blueprint
-
-#### 4. Add the secret to the service's ExternalSecret
-
-In the service's own `external-secret.yaml`, add a mapping for the same Infisical key:
+In the service's own `external-secret.yaml`, add a mapping for the Infisical key:
 
 ```yaml
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
         key: MY_SERVICE_OIDC_CLIENT_SECRET
 ```
+
+#### 4. Create the OAuth2 provider via Authentik API
+
+Run the following on the Mac mini after the service ExternalSecret has synced:
+
+```bash
+BOOTSTRAP_TOKEN=$(kubectl get secret authentik-secret -n authentik \
+  -o jsonpath='{.data.AUTHENTIK_BOOTSTRAP_TOKEN}' | base64 -d)
+
+OIDC_SECRET=$(kubectl get secret <service-secret> -n <namespace> \
+  -o jsonpath='{.data.OIDC_CLIENT_SECRET}' | base64 -d)
+
+AUTH_FLOW=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/flows/instances/?slug=default-provider-authorization-implicit-consent" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+
+INVAL_FLOW=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/flows/instances/?slug=default-provider-invalidation-flow" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+
+SIGNING_KEY=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/crypto/certificatekeypairs/?name=authentik+Self-signed+Certificate" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+
+SCOPE_OPENID=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/propertymappings/provider/scope/?scope_name=openid" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+SCOPE_EMAIL=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/propertymappings/provider/scope/?scope_name=email" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+SCOPE_PROFILE=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/propertymappings/provider/scope/?scope_name=profile" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+
+PROVIDER_PK=$(curl -sk -X POST \
+  -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/providers/oauth2/" \
+  -d "{
+    \"name\": \"<service-slug>\",
+    \"authorization_flow\": \"$AUTH_FLOW\",
+    \"invalidation_flow\": \"$INVAL_FLOW\",
+    \"client_type\": \"confidential\",
+    \"client_id\": \"<service-slug>\",
+    \"client_secret\": \"$OIDC_SECRET\",
+    \"redirect_uris\": [{\"matching_mode\": \"strict\", \"url\": \"https://holdens-mac-mini.story-larch.ts.net:<port>/auth/callback\"}],
+    \"signing_key\": \"$SIGNING_KEY\",
+    \"property_mappings\": [\"$SCOPE_OPENID\", \"$SCOPE_EMAIL\", \"$SCOPE_PROFILE\"]
+  }" | python3 -c "import json,sys; print(json.load(sys.stdin)['pk'])")
+
+curl -sk -X PATCH \
+  -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/core/applications/<service-slug>/" \
+  -d "{\"provider\": $PROVIDER_PK}"
+```
+
+Replace `<service-slug>`, `<service-secret>`, `<namespace>`, and `<port>` with actual values.
 
 #### 5. Configure the service to use OIDC
 
@@ -279,27 +274,21 @@ Standard Authentik endpoints:
 
 #### 6. Update documentation
 
-- Add the service to the [OIDC Providers](#oidc-providers) table above
+- Add the service to the [OIDC Providers](#oidc-providers) table
 - Add the service to the [Authentication Model](#authentication-model) table
 - Add the service to the [Application Inventory](#application-inventory) table
-- Add the Infisical key to the [Secrets in Infisical](#secrets-in-infisical) table
 - Update the service's own README with OIDC setup notes
 - Update `k8s/apps/external-secrets/README.md` with the new secret key
 
-#### 7. Commit, merge, verify
-
-Push changes, create PR, merge to `main`. ArgoCD will sync both the `authentik-config` and service applications. Verify:
+#### 7. Restart and verify
 
 ```bash
-# Check Authentik blueprint applied
-kubectl logs -n authentik -l app.kubernetes.io/component=worker --tail=50 | grep -i blueprint
+kubectl rollout restart deployment <service> -n <namespace>
 
-# Check the provider exists
-kubectl exec -n authentik deploy/authentik-server -- \
-  ak test_provider my-service 2>/dev/null || echo "Use Authentik Admin UI to verify"
+# Verify OIDC discovery
+curl -sk "https://holdens-mac-mini.story-larch.ts.net/application/o/<slug>/.well-known/openid-configuration" | python3 -m json.tool
 
-# Check the service pod has the OIDC config
-kubectl logs -n <namespace> deploy/<service> --tail=20
+# Test login via the service's OIDC button
 ```
 
 ## Operational Commands
@@ -336,6 +325,7 @@ kubectl get application authentik authentik-config -n argocd
 | 403 `insufficient_scope` on userinfo | Provider missing scope mappings | Assign `openid`, `email`, `profile` scope mappings to the provider in Authentik |
 | ArgoCD `malformed jwt: unexpected algorithm HS256` | Provider using HS256 instead of RS256 | Update the provider's signing key to an RS256 keypair in Authentik |
 | ArgoCD shows no applications after SSO login | RBAC policy.default is empty | Set `configs.rbac.policy.default: role:admin` in Terraform |
-| Blueprint `!Env` returns empty | Secret not in `authentik-secret` K8s Secret | Check Authentik ExternalSecret template has the key; force re-sync and restart Authentik pods |
-| Provider created but client_secret wrong | Infisical value mismatch | Ensure the same Infisical key is used by both Authentik and service ExternalSecrets; force re-sync both |
+| Service OIDC shows empty providers | Provider exists but service hasn't re-discovered | Restart the service deployment: `kubectl rollout restart deployment <service> -n <namespace>` |
+| Provider client_secret mismatch | Infisical value doesn't match what was passed to API | Re-create the provider via API with the current secret value; restart service pod |
+| OIDC discovery returns 404 | Provider not created or not linked to app | Run the API bootstrap script to create provider and link it to the application |
 | Blueprint not applying after ConfigMap change | Worker hasn't picked up the new ConfigMap | Restart the Authentik worker: `kubectl rollout restart deployment authentik-worker -n authentik` |

--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -55,24 +55,6 @@ data:
           meta_icon: https://avatars.githubusercontent.com/u/252820863?s=48&v=4
           meta_description: AI Agent Gateway Console
           meta_publisher: Homelab
-      - model: authentik_providers_oauth2.oauth2provider
-        id: provider-vikunja
-        state: present
-        identifiers:
-          name: vikunja
-        attrs:
-          name: vikunja
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
-          client_type: confidential
-          client_id: vikunja
-          client_secret: !Env VIKUNJA_OIDC_CLIENT_SECRET
-          redirect_uris: |
-            https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik
-          signing_key: !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
-          property_mappings:
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
       - model: authentik_core.application
         id: app-vikunja
         state: present
@@ -82,7 +64,6 @@ data:
           name: Vikunja
           slug: vikunja
           group: Productivity
-          provider: !KeyOf provider-vikunja
           meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8449
           meta_icon: https://avatars.githubusercontent.com/u/41270016?s=200&v=4
           meta_description: Todo List & Task Management

--- a/k8s/apps/authentik/external-secret.yaml
+++ b/k8s/apps/authentik/external-secret.yaml
@@ -21,7 +21,6 @@ spec:
         AUTHENTIK_BOOTSTRAP_TOKEN: "{{ .bootstrapToken }}"
         AUTHENTIK_POSTGRESQL__PASSWORD: "{{ .pgPassword }}"
         pg-password: "{{ .pgPassword }}"
-        VIKUNJA_OIDC_CLIENT_SECRET: "{{ .vikunjaOidcClientSecret }}"
   data:
     - secretKey: secretKey
       remoteRef:
@@ -35,6 +34,3 @@ spec:
     - secretKey: pgPassword
       remoteRef:
         key: AUTHENTIK_POSTGRES_PASSWORD
-    - secretKey: vikunjaOidcClientSecret
-      remoteRef:
-        key: VIKUNJA_OIDC_CLIENT_SECRET

--- a/k8s/apps/external-secrets/README.md
+++ b/k8s/apps/external-secrets/README.md
@@ -37,6 +37,11 @@ flowchart TD
         K8sS3["K8s Secret: openclaw-secret"]
     end
 
+    subgraph vikunjaNs["vikunja namespace"]
+        ES4["ExternalSecret: vikunja-db-secret"]
+        K8sS4["K8s Secret: vikunja-db-secret"]
+    end
+
     ESOApp -- "installs Helm chart\n(includes CRDs)" --> ESOOperator
     ESCApp -- "creates" --> CSS
     CSS -- "reads credentials from" --> MachineIdentitySecret
@@ -44,12 +49,15 @@ flowchart TD
     ESOOperator -- "watches" --> ES1
     ESOOperator -- "watches" --> ES2
     ESOOperator -- "watches" --> ES3
+    ESOOperator -- "watches" --> ES4
     ES1 -- "fetches via CSS" --> InfisicalAPI
     ES2 -- "fetches via CSS" --> InfisicalAPI
     ES3 -- "fetches via CSS" --> InfisicalAPI
+    ES4 -- "fetches via CSS" --> InfisicalAPI
     ES1 -- "creates/updates" --> K8sS1
     ES2 -- "creates/updates" --> K8sS2
     ES3 -- "creates/updates" --> K8sS3
+    ES4 -- "creates/updates" --> K8sS4
 ```
 
 ## Sync Wave Ordering
@@ -190,10 +198,10 @@ env:
 
 | ExternalSecret | Namespace | K8s Secret Created | Keys | Consumed By |
 |---|---|---|---|---|
-| `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password`, `VIKUNJA_OIDC_CLIENT_SECRET` | Authentik server + worker pods; embedded PostgreSQL; OIDC provider client secrets (via `!Env` in blueprints) |
+| `authentik-secret` | `authentik` | `authentik-secret` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRESQL__PASSWORD`, `pg-password` | Authentik server + worker pods; embedded PostgreSQL |
 | `grafana-secret` | `monitoring` | `grafana-secret` | `admin-user`, `admin-password`, `oauth-client-id`, `oauth-client-secret` | Grafana admin login; Grafana OIDC via Authentik |
 | `openclaw-secret` | `openclaw` | `openclaw-secret` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN` | OpenClaw gateway env vars, agent git workflow |
-| `vikunja-db-secret` | `vikunja` | `vikunja-db-secret` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `OIDC_CLIENT_SECRET` | PostgreSQL + Vikunja database credentials; Authentik OIDC client secret |
+| `vikunja-db-secret` | `vikunja` | `vikunja-db-secret` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `OIDC_CLIENT_SECRET` | PostgreSQL + Vikunja database credentials; OIDC client secret for Authentik provider |
 
 ## Security
 

--- a/k8s/apps/vikunja/README.md
+++ b/k8s/apps/vikunja/README.md
@@ -49,17 +49,75 @@ Before the first sync, add the following secrets to Infisical under `homelab / p
 
 The External Secrets Operator will sync these into a `vikunja-db-secret` in the `vikunja` namespace. Both the PostgreSQL and Vikunja deployments share the same password key — no duplication needed.
 
-### 2. Authentik OIDC Provider (fully code-managed)
+### 2. Create Authentik OIDC Provider (via API)
 
-Vikunja uses Authentik for SSO via OpenID Connect. The entire OIDC integration is managed via code — no manual Authentik UI steps required.
+Vikunja uses Authentik for SSO via OpenID Connect. The provider is created via the Authentik API — same one-time bootstrap pattern as ArgoCD and Grafana.
 
-**How the secret flows:**
+Run the following on the Mac mini (requires `kubectl` access):
+
+```bash
+BOOTSTRAP_TOKEN=$(kubectl get secret authentik-secret -n authentik \
+  -o jsonpath='{.data.AUTHENTIK_BOOTSTRAP_TOKEN}' | base64 -d)
+
+OIDC_SECRET=$(kubectl get secret vikunja-db-secret -n vikunja \
+  -o jsonpath='{.data.OIDC_CLIENT_SECRET}' | base64 -d)
+
+AUTH_FLOW=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/flows/instances/?slug=default-provider-authorization-implicit-consent" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+
+INVAL_FLOW=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/flows/instances/?slug=default-provider-invalidation-flow" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+
+SIGNING_KEY=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/crypto/certificatekeypairs/?name=authentik+Self-signed+Certificate" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+
+SCOPE_OPENID=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/propertymappings/provider/scope/?scope_name=openid" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+SCOPE_EMAIL=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/propertymappings/provider/scope/?scope_name=email" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+SCOPE_PROFILE=$(curl -sk -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/propertymappings/provider/scope/?scope_name=profile" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['results'][0]['pk'])")
+
+# Create the OAuth2 provider
+PROVIDER_PK=$(curl -sk -X POST \
+  -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/providers/oauth2/" \
+  -d "{
+    \"name\": \"vikunja\",
+    \"authorization_flow\": \"$AUTH_FLOW\",
+    \"invalidation_flow\": \"$INVAL_FLOW\",
+    \"client_type\": \"confidential\",
+    \"client_id\": \"vikunja\",
+    \"client_secret\": \"$OIDC_SECRET\",
+    \"redirect_uris\": [{\"matching_mode\": \"strict\", \"url\": \"https://holdens-mac-mini.story-larch.ts.net:8449/auth/openid/authentik\"}],
+    \"signing_key\": \"$SIGNING_KEY\",
+    \"property_mappings\": [\"$SCOPE_OPENID\", \"$SCOPE_EMAIL\", \"$SCOPE_PROFILE\"]
+  }" | python3 -c "import json,sys; print(json.load(sys.stdin)['pk'])")
+
+# Link the provider to the application (created by blueprint)
+curl -sk -X PATCH \
+  -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://holdens-mac-mini.story-larch.ts.net/api/v3/core/applications/vikunja/" \
+  -d "{\"provider\": $PROVIDER_PK}"
+
+# Restart Vikunja to discover the provider
+kubectl rollout restart deployment vikunja -n vikunja
+```
+
+**How the client secret flows:**
 
 1. `VIKUNJA_OIDC_CLIENT_SECRET` is stored once in Infisical
-2. Authentik ExternalSecret (`k8s/apps/authentik/external-secret.yaml`) pulls it into `authentik-secret` → available as env var in Authentik pods via `envFrom`
-3. Authentik Blueprint (`k8s/apps/authentik/blueprints-configmap.yaml`) reads it via `!Env VIKUNJA_OIDC_CLIENT_SECRET` and sets it as the OAuth2 provider's `client_secret`
-4. Vikunja ExternalSecret (`k8s/apps/vikunja/external-secret.yaml`) also pulls it → mounted as a file at `/secrets/oidc-client-secret`
-5. Vikunja config (`k8s/apps/vikunja/vikunja-config.yaml`) references the file for `clientsecret`
+2. Vikunja ExternalSecret pulls it into `vikunja-db-secret` → mounted as a file at `/secrets/oidc-client-secret`
+3. Vikunja config (`vikunja-config.yaml`) references the file for `clientsecret`
+4. The same secret value is passed to the Authentik API when creating the provider (read from the K8s secret at creation time)
 
 **OIDC details:**
 
@@ -144,12 +202,13 @@ Note: Changing the PostgreSQL `POSTGRES_PASSWORD` requires a database password u
 - **No metrics in Prometheus:** Confirm the ServiceMonitor has been synced and the `vikunja` Service has the correct labels.
 - **External access not working:** Ensure Tailscale routing to the node and that the NodePort is within the allowed range (30000-32767). Check service `type: NodePort` and `nodePort: 30888`.
 - **OIDC "Login with Authentik" not showing:** Check that `vikunja-config` ConfigMap is mounted at `/etc/vikunja/config.yml` and the `auth.openid.enabled` is `true`. Verify the pod has restarted after ConfigMap changes.
-- **OIDC "invalid client" error:** Verify `VIKUNJA_OIDC_CLIENT_SECRET` in Infisical matches what the Authentik provider has. Force re-sync both ExternalSecrets (`authentik-secret` and `vikunja-db-secret`) and restart both pods.
+- **OIDC "invalid client" error:** Verify `VIKUNJA_OIDC_CLIENT_SECRET` in Infisical matches what the Authentik provider has. Force re-sync ExternalSecret (`vikunja-db-secret`) and restart both pods.
+- **OIDC discovery returns 404:** The Authentik provider does not exist or is not linked to the application. Re-run the API bootstrap script from Step 2.
 
 ## References
 
 - [Vikunja Documentation](https://vikunja.io)
 - [Vikunja OpenID Connect](https://vikunja.io/docs/openid)
 - [Vikunja GitHub](https://github.com/go-vikunja/vikunja)
-- [Authentik Blueprints — YAML Tags](https://docs.goauthentik.io/customize/blueprints/v1/tags)
+- [Authentik API Reference](https://docs.goauthentik.io/developer-docs/api/)
 - [Authentik OIDC Provider](https://docs.goauthentik.io/docs/add-secure-apps/providers/oauth2/)


### PR DESCRIPTION
## Summary

- Remove the broken `authentik_providers_oauth2.oauth2provider` blueprint entry that uses `!Find [authentik_providers_oauth2.scopemapping, ...]` — this fails silently in Authentik 2025.12.4, causing the provider to never be created
- Remove `VIKUNJA_OIDC_CLIENT_SECRET` from `authentik-secret` ExternalSecret (no longer needed since provider is created via API, not blueprint `!Env`)
- Blueprint now manages only application metadata (name, icon, group, launch URL); provider is created and linked via one-time Authentik API call
- Update all documentation (vikunja, authentik, external-secrets READMEs) with API-based provider creation scripts and updated architecture diagrams

This aligns Vikunja's OIDC provider creation with the same pattern used for ArgoCD and Grafana — one-time API bootstrap, client-side config in git.

**Supersedes PR #96** (which proposed manual UI steps instead).

## Test plan

- [ ] ArgoCD syncs `authentik-config` and `vikunja` without errors
- [ ] Blueprint applies cleanly (no `status: error` on the blueprint instance)
- [ ] `authentik-secret` no longer contains `VIKUNJA_OIDC_CLIENT_SECRET`
- [ ] Vikunja OIDC provider exists in Authentik (already created via API)
- [ ] Vikunja `/api/v1/info` shows `providers: [{name: "Login with Authentik"}]`
- [ ] Login via Authentik SSO works end-to-end


Made with [Cursor](https://cursor.com)