### PR TITLE
docs: update all documentation for v1.6.0 Vikunja addition

### DIFF
--- a/.doc-manifest.yml
+++ b/.doc-manifest.yml
@@ -56,9 +56,18 @@ documents:
     sources:
       - k8s/apps/trivy-dashboard/
 
+  - doc: k8s/apps/vikunja/README.md
+    sources:
+      - k8s/apps/vikunja/
+
   - doc: terraform/README.md
     sources:
       - terraform/
+
+  # ── Service index (tracks when new apps are added to ArgoCD) ──
+  - doc: docs/services/index.md
+    sources:
+      - k8s/apps/argocd/kustomization.yaml
 
   # ── Cross-cutting documentation (real content, not thin wrappers) ──
   - doc: docs/getting-started/architecture.md
@@ -74,10 +83,12 @@ documents:
     sources:
       - k8s/apps/external-secrets/
       - k8s/apps/infisical/
+      - k8s/apps/vikunja/external-secret.yaml
 
   - doc: docs/infrastructure/networking.md
     sources:
       - k8s/apps/networking-policies/
+      - k8s/apps/vikunja/vikunja-service.yaml
 
   - doc: docs/infrastructure/security.md
     sources:
@@ -87,6 +98,8 @@ documents:
       - k8s/apps/openclaw/external-secret.yaml
       - k8s/apps/namespace-security/
       - k8s/apps/networking-policies/
+      - k8s/apps/vikunja/vikunja-deployment.yaml
+      - k8s/apps/vikunja/external-secret.yaml
 
   - doc: docs/operations/ai-agents.md
     sources:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homelab
 
-A GitOps-managed Kubernetes homelab running on OrbStack (Mac mini M4). Deploys self-hosted infrastructure services -- Authentik SSO, Grafana + Prometheus, Infisical, Trivy Operator, and OpenClaw AI gateway -- orchestrated by Argo CD, with security hardening (network policies, Pod Security Standards, non-root execution, vulnerability scanning) and AI agent skill definitions for multi-agent development workflows. All services are accessible from any device on the Tailscale network (iPhone, iPad, Mac).
+A GitOps-managed Kubernetes homelab running on OrbStack (Mac mini M4). Deploys self-hosted infrastructure services -- Authentik SSO, Grafana + Prometheus, Infisical, Trivy Operator, OpenClaw AI gateway, and Vikunja task management -- orchestrated by Argo CD, with security hardening (network policies, Pod Security Standards, non-root execution, vulnerability scanning) and AI agent skill definitions for multi-agent development workflows. All services are accessible from any device on the Tailscale network (iPhone, iPad, Mac).
 
 ## Architecture
 
@@ -51,6 +51,10 @@ flowchart TD
         subgraph trivyDashNs["trivy-dashboard namespace"]
             TrivyDash["Trivy Dashboard\nNodePort :30448"]
         end
+
+        subgraph vikunjaNs["vikunja namespace"]
+            VikunjaPod["Vikunja\nNodePort :30888"]
+        end
     end
 
     TF -- "Helm release" --> ArgoCD
@@ -64,6 +68,7 @@ flowchart TD
     ArgoCD -- "App of Apps" --> monNs
     ArgoCD -- "App of Apps" --> openclawNs
     ArgoCD -- "App of Apps" --> trivyDashNs
+    ArgoCD -- "App of Apps" --> vikunjaNs
     ArgoCD -- "manages" --> NsPolicies
     ArgoCD -- "manages" --> NetPolicies
     TrivyOp -->|watches pods| monNs
@@ -72,12 +77,14 @@ flowchart TD
     CSS -- "ExternalSecret" --> OpenClawPod
     CSS -- "ExternalSecret" --> AuthentikPod
     CSS -- "ExternalSecret" --> GrafanaPod
+    CSS -- "ExternalSecret" --> VikunjaPod
     TServe -- ":443 -> :30500" --> AuthentikPod
     TServe -- ":8443 -> :30080" --> ArgoCD
     TServe -- ":8444 -> :30090" --> GrafanaPod
     TServe -- ":8445 -> :30445" --> InfisicalSvc
     TServe -- ":8447 -> :30789" --> OpenClawPod
     TServe -- ":8448 -> :30448" --> TrivyDash
+    TServe -- ":8449 -> :30888" --> VikunjaPod
 ```
 
 ## Repository Structure
@@ -109,7 +116,8 @@ homelab/
 │       ├── networking-policies/   # Default-deny NetworkPolicy per namespace
 │       ├── openclaw/              # OpenClaw AI gateway kustomize manifests
 │       ├── trivy-operator/        # Container image vulnerability scanning
-│       └── trivy-dashboard/       # Trivy Operator Dashboard web UI
+│       ├── trivy-dashboard/       # Trivy Operator Dashboard web UI
+│       └── vikunja/               # Vikunja todo list app with OIDC SSO
 ├── docs/                          # MkDocs documentation site
 ├── agents/                        # OpenClaw agent definitions
 │   └── workspaces/                # Per-agent AGENTS.md personality files (5 agents)
@@ -152,6 +160,7 @@ sequenceDiagram
 | Trivy Operator | Helm chart via ArgoCD | `monitoring` | internal only (CRs: `kubectl get vulnerabilityreports -A`) |
 | Trivy Dashboard | Kustomize via ArgoCD | `trivy-dashboard` | `https://holdens-mac-mini.story-larch.ts.net:8448` |
 | OpenClaw | Kustomize via ArgoCD | `openclaw` | `https://holdens-mac-mini.story-larch.ts.net:8447` |
+| Vikunja | Kustomize via ArgoCD | `vikunja` | `https://holdens-mac-mini.story-larch.ts.net:8449` |
 | Namespace Security | Kustomize via ArgoCD | `argocd` | cluster-wide Pod Security Standard labels |
 | Network Policies | Kustomize via ArgoCD | `argocd` | default-deny ingress/egress per namespace |
 
@@ -202,6 +211,10 @@ Once ArgoCD deploys Infisical (check: `kubectl get pods -n infisical`), open the
 | `OPENROUTER_API_KEY` | OpenRouter API key from [openrouter.ai/keys](https://openrouter.ai/keys) |
 | `GEMINI_API_KEY` | Google Gemini API key from [aistudio.google.com/apikey](https://aistudio.google.com/apikey) |
 | `GITHUB_TOKEN` | GitHub personal access token for OpenClaw agent git operations |
+| `VIKUNJA_POSTGRES_USER` | Vikunja PostgreSQL username |
+| `VIKUNJA_POSTGRES_PASSWORD` | Vikunja PostgreSQL password |
+| `VIKUNJA_POSTGRES_DB` | Vikunja PostgreSQL database name |
+| `VIKUNJA_OIDC_CLIENT_SECRET` | Authentik OAuth2 client secret for Vikunja |
 
 Then create a Machine Identity in Infisical (`Settings → Machine Identities → Universal Auth`), grant it **Member** access to the `homelab` project, update `terraform/terraform.tfvars` with the new `clientId` / `clientSecret`, and re-run `terraform apply` to update the credential. See [docs/getting-started/bootstrap.md](docs/getting-started/bootstrap.md) for the full step-by-step.
 
@@ -216,6 +229,7 @@ tailscale serve --bg --https 8444 http://localhost:30090          # Grafana
 tailscale serve --bg --https 8445 http://localhost:30445          # Infisical
 tailscale serve --bg --https 8447 http://localhost:30789          # OpenClaw
 tailscale serve --bg --https 8448 http://localhost:30448          # Trivy Dashboard
+tailscale serve --bg --https 8449 http://localhost:30888          # Vikunja
 
 tailscale serve status
 ```
@@ -228,6 +242,7 @@ Access URLs (any Tailscale device):
 - Infisical: `https://holdens-mac-mini.story-larch.ts.net:8445`
 - OpenClaw: `https://holdens-mac-mini.story-larch.ts.net:8447`
 - Trivy Dashboard: `https://holdens-mac-mini.story-larch.ts.net:8448`
+- Vikunja: `https://holdens-mac-mini.story-larch.ts.net:8449`
 
 ### Verify Deployment
 
@@ -262,6 +277,7 @@ kubectl get pods -A | grep -v Running | grep -v Completed
 | [docs/services/openclaw.md](docs/services/openclaw.md) | OpenClaw AI gateway deployment, image builds, multi-agent architecture |
 | [docs/services/trivy-operator.md](docs/services/trivy-operator.md) | Container image vulnerability scanning, ClientServer mode, Helm values |
 | [docs/services/trivy-dashboard.md](docs/services/trivy-dashboard.md) | Trivy Operator Dashboard web UI, vulnerability report viewer |
+| [docs/services/vikunja.md](docs/services/vikunja.md) | Vikunja todo list app, OIDC integration, PostgreSQL setup |
 | **Operations** | |
 | [docs/operations/git-workflow.md](docs/operations/git-workflow.md) | Branch conventions, PR requirements, post-merge cleanup for Cursor and OpenClaw |
 | [docs/operations/ai-agents.md](docs/operations/ai-agents.md) | Cursor rules + OpenClaw agents/skills, when to use which |
@@ -295,3 +311,5 @@ When adding a new service or documentation file, add an entry to `.doc-manifest.
 > **Completed in v1.1.0:** Security hardening — network policies (default-deny per namespace), Pod Security Standards enforcement, RBAC scope-down (OpenClaw cluster-admin removed), non-root execution for all services, and container image vulnerability scanning (Trivy Operator).
 
 > **Completed in v1.2.0:** Infrastructure optimization & observability — automated nightly shutdown/startup, monitoring dashboards and alerting rules as code, Gitea/PostgreSQL decommissioned (GitHub adopted), Authentik app portal with bookmarks, Trivy Dashboard, agent skills optimization.
+
+> **Completed in v1.6.0:** Vikunja todo list application with OIDC authentication via Authentik, PostgreSQL database with persistent storage, Prometheus metrics, and full Tailscale Serve integration.

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -66,7 +66,7 @@ Applications are organized into three **AppProjects** that scope which repos, na
 |---|---|---|
 | `secrets` | Secret management infrastructure | `infisical`, `external-secrets`, `external-secrets-config` |
 | `data` | Databases and data stores | (reserved for future use) |
-| `apps` | User-facing applications | `monitoring`, `authentik`, `openclaw`, `trivy-operator`, `trivy-operator-vulnerability-scanner`, `trivy-dashboard`, `namespace-security`, `networking-policies` |
+| `apps` | User-facing applications | `monitoring`, `authentik`, `openclaw`, `trivy-operator`, `trivy-operator-vulnerability-scanner`, `trivy-dashboard`, `vikunja`, `namespace-security`, `networking-policies` |
 | `default` | Bootstrap only | `argocd-apps` (root) |
 
 ```mermaid
@@ -98,6 +98,7 @@ flowchart LR
             OCApp["openclaw"]
             TrivyApp["trivy-operator"]
             TrivyDashApp["trivy-dashboard"]
+            VikApp["vikunja"]
             NSApp["namespace-security"]
             NPApp["networking-policies"]
         end
@@ -215,11 +216,19 @@ flowchart TD
         TrivyDashPod["Trivy Dashboard\nNodePort :30448"]
     end
 
+    subgraph vikunjaNs["vikunja namespace"]
+        VikunjaPod["Vikunja\nNodePort :30888"]
+        VikunjaPG["PostgreSQL\n(Vikunja internal)"]
+        VikunjaPod --> VikunjaPG
+    end
+
     AuthentikPod -. "OIDC" .-> GrafanaPod
     AuthentikPod -. "OIDC" .-> ArgoServer
+    AuthentikPod -. "OIDC" .-> VikunjaPod
     ESOPod --> CSS
     CSS -- "Universal Auth" --> InfisicalPod
     CSS -- "ExternalSecret" --> OpenClawPod
+    CSS -- "ExternalSecret" --> VikunjaPod
     OpenClawPod -- "primary" --> OpenRouterAPI["OpenRouter\nstepfun/step-3.5-flash:free"]
     OpenClawPod -. "fallback" .-> GeminiAPI["Google Gemini\ngemini-2.5-pro"]
     ArgoController -- "poll git" --> GitHub["GitHub\nholdennguyen/homelab"]
@@ -236,6 +245,7 @@ Services are exposed through **Tailscale Serve**, which provides automatic TLS c
 | Grafana | `:30090` | `https://holdens-mac-mini.story-larch.ts.net:8444` | 8444 | SSO via Authentik |
 | Infisical | `:30445` | `https://holdens-mac-mini.story-larch.ts.net:8445` | 8445 | Local admin |
 | OpenClaw | `:30789` | `https://holdens-mac-mini.story-larch.ts.net:8447` | 8447 | Local |
+| Vikunja | `:30888` | `https://holdens-mac-mini.story-larch.ts.net:8449` | 8449 | SSO via Authentik |
 | Trivy Dashboard | `:30448` | `https://holdens-mac-mini.story-larch.ts.net:8448` | 8448 | Bookmark via Authentik |
 
 For the full networking reference, see [docs/networking.md](../infrastructure/networking.md).
@@ -282,6 +292,7 @@ homelab/
 │       ├── openclaw/               # OpenClaw AI gateway manifests
 │       ├── trivy-operator/         # Trivy vulnerability scanner (README only; deployed via Helm)
 │       ├── trivy-dashboard/       # Trivy Operator Dashboard web UI
+│       ├── vikunja/               # Vikunja todo list app with OIDC SSO
 │       ├── namespace-security/     # Pod Security Standard labels for namespaces
 │       └── networking-policies/    # Default-deny NetworkPolicies for all namespaces
 ├── docs/                           # MkDocs documentation site

--- a/docs/infrastructure/networking.md
+++ b/docs/infrastructure/networking.md
@@ -48,6 +48,9 @@ flowchart TD
             subgraph trivyDashNs["trivy-dashboard namespace"]
                 TrivyDashSvc["trivy-dashboard\nNodePort 30448"]
             end
+            subgraph vikunjaNs["vikunja namespace"]
+                VikunjaSvc["vikunja\nNodePort 30888"]
+            end
         end
 
         TLS443 -- "http://localhost:30500" --> AuthentikSvc
@@ -55,6 +58,7 @@ flowchart TD
         TLS8444 -- "http://localhost:30090" --> GrafanaSvc
             TLS8445["HTTPS :8445"] -- "http://localhost:30445" --> InfisicalSvc
             TLS8448["HTTPS :8448"] -- "http://localhost:30448" --> TrivyDashSvc
+            TLS8449["HTTPS :8449"] -- "http://localhost:30888" --> VikunjaSvc
     end
 
     iPhone -- "https://holdens-mac-mini\n.story-larch.ts.net" --> TLS443
@@ -107,6 +111,7 @@ sequenceDiagram
 | Infisical | 8080 | 30445 | `http://localhost:30445` |
 | Trivy Dashboard | 8900 | 30448 | `http://localhost:30448` |
 | OpenClaw | 18789 | 30789 | `http://localhost:30789` |
+| Vikunja | 3456 | 30888 | `http://localhost:30888` |
 
 ## Layer 2: Tailscale Serve
 
@@ -132,6 +137,9 @@ tailscale serve --bg --https 8448 http://localhost:30448
 
 # OpenClaw — custom HTTPS port (8447)
 tailscale serve --bg --https 8447 http://localhost:30789
+
+# Vikunja — custom HTTPS port (8449)
+tailscale serve --bg --https 8449 http://localhost:30888
 ```
 
 The `--bg` flag runs the proxy as a persistent background service that survives terminal sessions.
@@ -186,6 +194,9 @@ https://holdens-mac-mini.story-larch.ts.net:8447 (tailnet only)
 
 https://holdens-mac-mini.story-larch.ts.net:8448 (tailnet only)
 |-- / proxy http://localhost:30448
+
+https://holdens-mac-mini.story-larch.ts.net:8449 (tailnet only)
+|-- / proxy http://localhost:30888
 ```
 
 ### Manage Serve
@@ -205,6 +216,9 @@ tailscale serve --https=8448 off
 
 # Stop OpenClaw proxy
 tailscale serve --https=8447 off
+
+# Stop Vikunja proxy
+tailscale serve --https=8449 off
 
 # Reset all serve config
 tailscale serve reset
@@ -230,9 +244,9 @@ Tailscale's MagicDNS automatically resolves `<hostname>.story-larch.ts.net` to t
 | ArgoCD | `https://holdens-mac-mini.story-larch.ts.net:8443` | 8443 | SSO via Authentik |
 | Grafana | `https://holdens-mac-mini.story-larch.ts.net:8444` | 8444 | SSO via Authentik |
 | Infisical | `https://holdens-mac-mini.story-larch.ts.net:8445` | 8445 | Local admin |
-| Gitea | `https://holdens-mac-mini.story-larch.ts.net:8446` | 8446 | SSO via Authentik |
-| Trivy Dashboard | `https://holdens-mac-mini.story-larch.ts.net:8448` | 8448 | SSO portal bookmark |
 | OpenClaw | `https://holdens-mac-mini.story-larch.ts.net:8447` | 8447 | SSO portal bookmark |
+| Trivy Dashboard | `https://holdens-mac-mini.story-larch.ts.net:8448` | 8448 | SSO portal bookmark |
+| Vikunja | `https://holdens-mac-mini.story-larch.ts.net:8449` | 8449 | SSO via Authentik |
 
 ### Tailscale Serve vs Funnel
 
@@ -265,7 +279,7 @@ flowchart TD
 
     subgraph tailnet["Tailscale Tailnet (story-larch)"]
         subgraph mac["Mac mini M4\n100.77.144.4"]
-            TS["tailscale serve\n:443, :8443, :8444, :8445, :8447, :8448"]
+            TS["tailscale serve\n:443, :8443, :8444, :8445, :8447, :8448, :8449"]
 
             subgraph orb["OrbStack Kubernetes"]
                 subgraph authentik["authentik ns"]
@@ -287,6 +301,9 @@ flowchart TD
                 subgraph openclaw_ns["openclaw ns"]
                     OpenClawSvc["openclaw\nNodePort 30789"]
                 end
+                subgraph vikunja_ns["vikunja ns"]
+                    VikunjaSvc2["vikunja\nNodePort 30888"]
+                end
             end
 
             TS -- "localhost:30500" --> AuthentikSvc2
@@ -295,6 +312,7 @@ flowchart TD
             TS -- "localhost:30445" --> InfisicalSvc2
             TS -- "localhost:30448" --> TrivyDashSvc2
             TS -- "localhost:30789" --> OpenClawSvc
+            TS -- "localhost:30888" --> VikunjaSvc2
             ArgoCtrl -- "poll" --> GitHub
             LetsEncrypt -. "auto cert" .-> TS
         end
@@ -336,6 +354,8 @@ Additionally, namespace-specific rules enable required connectivity:
 - **API Server Access**: Namespaces that need to communicate with the Kubernetes API (e.g., `argocd`, `openclaw`, `monitoring`, `external-secrets`) have an egress rule permitting traffic to the API server on port 6443.
 - **Internet Egress**: The `argocd` and `openclaw` namespaces are allowed to egress to the internet on ports 443 (HTTPS) and 22 (SSH) to facilitate Git operations and external API calls.
 - **External Secrets**: The `external-secrets` namespace can egress to the Infisical API (`infisical` namespace, port 8080); conversely, `infisical` has an ingress rule allowing traffic from `external-secrets` on that port.
+
+Additionally, the `vikunja` namespace follows the same pattern with deny-all, allow-same-namespace, allow-dns, and Tailscale ingress on port 3456.
 
 The complete set of policies is stored in `k8s/apps/networking-policies/`.
 

--- a/docs/infrastructure/secret-management.md
+++ b/docs/infrastructure/secret-management.md
@@ -46,6 +46,9 @@ flowchart TD
         subgraph openclawNs["openclaw namespace"]
             openclaw_secret["openclaw-secret\n(created by ESO)"]
         end
+        subgraph vikunjaNs["vikunja namespace"]
+            vikunja_secret["vikunja-db-secret\n(created by ESO)"]
+        end
         subgraph argocdNs2["argocd namespace"]
             argocd_secret["argocd-secret\n(admin.password set by Helm)"]
         end
@@ -55,6 +58,7 @@ flowchart TD
         AUTHENTIK_SECRETS["AUTHENTIK_SECRET_KEY\nAUTHENTIK_BOOTSTRAP_PASSWORD\nAUTHENTIK_BOOTSTRAP_TOKEN\nAUTHENTIK_POSTGRES_PASSWORD"]
         GRAFANA_SECRETS["GRAFANA_ADMIN_PASSWORD\nGRAFANA_OAUTH_CLIENT_SECRET"]
         OPENCLAW_SECRETS["OPENCLAW_GATEWAY_TOKEN\nOPENROUTER_API_KEY\nGEMINI_API_KEY\nGITHUB_TOKEN\nDISCORD_BOT_TOKEN"]
+        VIKUNJA_SECRETS["VIKUNJA_POSTGRES_USER\nVIKUNJA_POSTGRES_PASSWORD\nVIKUNJA_POSTGRES_DB\nVIKUNJA_OIDC_CLIENT_SECRET"]
     end
 
     TFVars --> TFState
@@ -67,6 +71,7 @@ flowchart TD
     AUTHENTIK_SECRETS --> authentik_secret
     GRAFANA_SECRETS --> grafana_secret
     OPENCLAW_SECRETS --> openclaw_secret
+    VIKUNJA_SECRETS --> vikunja_secret
 ```
 
 ## Bootstrap Secrets (Terraform-Managed)
@@ -100,6 +105,10 @@ flowchart LR
                         s18["GEMINI_API_KEY"]
                         s19["GITHUB_TOKEN"]
                         s20["DISCORD_BOT_TOKEN"]
+                        s21["VIKUNJA_POSTGRES_USER"]
+                        s22["VIKUNJA_POSTGRES_PASSWORD"]
+                        s23["VIKUNJA_POSTGRES_DB"]
+                        s24["VIKUNJA_OIDC_CLIENT_SECRET"]
                     end
                 end
             end

--- a/docs/infrastructure/security.md
+++ b/docs/infrastructure/security.md
@@ -81,6 +81,7 @@ Every application namespace has a `default-deny-all` NetworkPolicy that blocks a
 | `openclaw` | deny-all, allow-same-ns, allow-dns | Tailscale ingress (:18789), API server egress (:6443), internet egress (:443) |
 | `external-secrets` | deny-all, allow-same-ns, allow-dns | API server egress (:6443), Infisical egress (:8080) |
 | `infisical` | deny-all, allow-same-ns, allow-dns | Tailscale ingress (:8080), ingress from `external-secrets` (:8080) |
+| `vikunja` | deny-all, allow-same-ns, allow-dns | Tailscale ingress (:3456) |
 
 Tailscale ingress rules are locked to the CGNAT range `100.64.0.0/10`, ensuring only tailnet devices can reach services.
 
@@ -99,6 +100,7 @@ Namespaces are labeled with Kubernetes Pod Security Standards (PSS) to control w
 | `authentik` | `baseline` | `restricted` | server/worker containers run as root, missing seccompProfile |
 | `infisical` | `baseline` | `restricted` | standalone + ingress-nginx run as root, missing seccompProfile |
 | `openclaw` | — | — | Excluded: uses hostPath volumes disallowed by the restricted profile |
+| `vikunja` | `baseline` | `restricted` | Vikunja runs as UID 1000; PostgreSQL runs as UID 70 |
 
 Namespaces at `baseline` enforce + `restricted` audit/warn log violations without blocking pods, surfacing non-compliant workloads in audit logs for future remediation.
 
@@ -150,6 +152,7 @@ flowchart LR
 | `openclaw-secret` | `openclaw` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN` |
 | `authentik-secret` | `authentik` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRES_PASSWORD` |
 | `grafana-secret` | `monitoring` | `GRAFANA_ADMIN_PASSWORD`, `GRAFANA_OAUTH_CLIENT_SECRET` |
+| `vikunja-db-secret` | `vikunja` | `VIKUNJA_POSTGRES_USER`, `VIKUNJA_POSTGRES_PASSWORD`, `VIKUNJA_POSTGRES_DB`, `VIKUNJA_OIDC_CLIENT_SECRET` |
 
 ## Container Security
 
@@ -162,6 +165,7 @@ flowchart LR
 | ESO | Helm-managed | `true` | `true` | Restricted PSS compliant |
 | Infisical | root | no | no | Upstream Helm default; hardening tracked in roadmap |
 | Authentik | root | no | no | Upstream Helm default; hardening tracked in roadmap |
+| Vikunja | 1000 | `true` | no | Runs as non-root; PostgreSQL runs as UID 70 |
 
 ### Image Provenance
 
@@ -172,6 +176,7 @@ flowchart LR
 | ESO | `ghcr.io/external-secrets/external-secrets` | Official upstream (Helm chart) | Chart version pinned |
 | Prometheus/Grafana | kube-prometheus-stack images | Official upstream (Helm chart) | Chart version pinned |
 | Trivy | `aquasecurity/trivy` | Official upstream (Helm chart) | Chart version pinned |
+| Vikunja | `vikunja/vikunja:1.1.0` | Official upstream (Docker Hub) | Tag pinned |
 
 ## Supply Chain Security
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -16,3 +16,4 @@ Per-service documentation for every deployed application. Each page includes the
 | [OpenClaw](openclaw.md) | `openclaw` | Multi-agent AI gateway |
 | [Trivy Operator](trivy-operator.md) | `monitoring` | Container image vulnerability scanning |
 | [Trivy Dashboard](trivy-dashboard.md) | `trivy-dashboard` | Vulnerability report web UI |
+| [Vikunja](vikunja.md) | `vikunja` | Todo list and task management with OIDC SSO |

--- a/docs/services/vikunja.md
+++ b/docs/services/vikunja.md
@@ -1,0 +1,7 @@
+---
+title: Vikunja
+---
+
+{%
+   include-markdown "../../k8s/apps/vikunja/README.md"
+%}

--- a/k8s/apps/argocd/README.md
+++ b/k8s/apps/argocd/README.md
@@ -82,7 +82,7 @@ flowchart LR
     end
 
     subgraph dataProj["data project"]
-        A3["postgresql"]
+        A3["(reserved)"]
     end
 
     subgraph appsProj["apps project"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - OpenClaw: services/openclaw.md
       - Trivy Operator: services/trivy-operator.md
       - Trivy Dashboard: services/trivy-dashboard.md
+      - Vikunja: services/vikunja.md
   - Operations:
       - operations/index.md
       - Git Workflow: operations/git-workflow.md


### PR DESCRIPTION
## Summary

- Add Vikunja service documentation across all cross-cutting docs (README, architecture, networking, secret-management, security)
- Create `docs/services/vikunja.md` thin wrapper for MkDocs and add to navigation
- Fix doc-freshness automation gaps: add vikunja README tracking, `docs/services/index.md` tracking, and expand cross-cutting doc sources to include vikunja manifests
- Fix stale Gitea reference in networking access URLs (decommissioned in v1.2.0)
- Fix stale `postgresql` placeholder in ArgoCD data project diagram (should be `(reserved)`)

### Docs freshness before

```
Summary: 12/18 up-to-date, 6 stale
```

Stale: `README.md`, `k8s/apps/argocd/README.md`, `docs/getting-started/architecture.md`, `docs/infrastructure/secret-management.md`, `docs/infrastructure/networking.md`, `docs/infrastructure/security.md`

### Docs freshness after

```
Summary: 20/20 up-to-date, 0 stale
```

### Automation fixes in `.doc-manifest.yml`

| Issue | Fix |
|---|---|
| Vikunja service README not tracked | Added `k8s/apps/vikunja/README.md` entry |
| `docs/services/index.md` not tracked (new services go undetected) | Added entry tracking `k8s/apps/argocd/kustomization.yaml` |
| Networking doc misses new service ports | Added `k8s/apps/vikunja/vikunja-service.yaml` to sources |
| Secret-management doc misses new ExternalSecrets | Added `k8s/apps/vikunja/external-secret.yaml` to sources |
| Security doc misses new service deployments | Added `k8s/apps/vikunja/vikunja-deployment.yaml` and `external-secret.yaml` to sources |

## Test plan

- [x] `python3 scripts/doc-freshness.py` reports 20/20 up-to-date, 0 stale
- [ ] Verify MkDocs builds without errors (`mkdocs build`)
- [ ] Verify Vikunja page renders correctly on the docs site
- [ ] Tag as `v1.6.1` after merge


Made with [Cursor](https://cursor.com)