### PR TITLE
fix: resolve LaunchFast port conflict with Grafana (8444→8446)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ tailscale serve --bg http://localhost:30500                       # Authentik (S
 tailscale serve --bg --https 8443 http://localhost:30080          # ArgoCD
 tailscale serve --bg --https 8444 http://localhost:30090          # Grafana
 tailscale serve --bg --https 8445 http://localhost:30445          # Infisical
+tailscale serve --bg --https 8446 http://localhost:30100          # LaunchFast
 tailscale serve --bg --https 8447 http://localhost:30789          # OpenClaw
 tailscale serve --bg --https 8448 http://localhost:30448          # Trivy Dashboard
 tailscale serve --bg --https 8449 http://localhost:30888          # Vikunja
@@ -240,6 +241,7 @@ Access URLs (any Tailscale device):
 - ArgoCD: `https://holdens-mac-mini.story-larch.ts.net:8443`
 - Grafana: `https://holdens-mac-mini.story-larch.ts.net:8444`
 - Infisical: `https://holdens-mac-mini.story-larch.ts.net:8445`
+- LaunchFast: `https://holdens-mac-mini.story-larch.ts.net:8446`
 - OpenClaw: `https://holdens-mac-mini.story-larch.ts.net:8447`
 - Trivy Dashboard: `https://holdens-mac-mini.story-larch.ts.net:8448`
 - Vikunja: `https://holdens-mac-mini.story-larch.ts.net:8449`

--- a/docs/getting-started/bootstrap.md
+++ b/docs/getting-started/bootstrap.md
@@ -223,6 +223,9 @@ tailscale serve --bg --https 8444 http://localhost:30090
 # Infisical — custom HTTPS port 8445
 tailscale serve --bg --https 8445 http://localhost:30445
 
+# LaunchFast — custom HTTPS port 8446
+tailscale serve --bg --https 8446 http://localhost:30100
+
 # OpenClaw — custom HTTPS port 8447
 tailscale serve --bg --https 8447 http://localhost:30789
 
@@ -250,6 +253,9 @@ https://holdens-mac-mini.story-larch.ts.net:8444 (tailnet only)
 
 https://holdens-mac-mini.story-larch.ts.net:8445 (tailnet only)
 |-- / proxy http://localhost:30445
+
+https://holdens-mac-mini.story-larch.ts.net:8446 (tailnet only)
+|-- / proxy http://localhost:30100
 
 https://holdens-mac-mini.story-larch.ts.net:8447 (tailnet only)
 |-- / proxy http://localhost:30789
@@ -282,6 +288,7 @@ Access URLs after bootstrap:
 | ArgoCD | `https://holdens-mac-mini.story-larch.ts.net:8443` | SSO via Authentik |
 | Grafana | `https://holdens-mac-mini.story-larch.ts.net:8444` | SSO via Authentik |
 | Infisical | `https://holdens-mac-mini.story-larch.ts.net:8445` | Local admin |
+| LaunchFast | `https://holdens-mac-mini.story-larch.ts.net:8446` | Bookmark via Authentik |
 | OpenClaw | `https://holdens-mac-mini.story-larch.ts.net:8447` | Local |
 | Trivy Dashboard | `https://holdens-mac-mini.story-larch.ts.net:8448` | Bookmark via Authentik |
 

--- a/docs/infrastructure/networking.md
+++ b/docs/infrastructure/networking.md
@@ -132,6 +132,9 @@ tailscale serve --bg --https 8444 http://localhost:30090
 # Infisical — custom HTTPS port (8445)
 tailscale serve --bg --https 8445 http://localhost:30445
 
+# LaunchFast — custom HTTPS port (8446)
+tailscale serve --bg --https 8446 http://localhost:30100
+
 # Trivy Dashboard — custom HTTPS port (8448)
 tailscale serve --bg --https 8448 http://localhost:30448
 
@@ -189,6 +192,9 @@ https://holdens-mac-mini.story-larch.ts.net:8444 (tailnet only)
 https://holdens-mac-mini.story-larch.ts.net:8445 (tailnet only)
 |-- / proxy http://localhost:30445
 
+https://holdens-mac-mini.story-larch.ts.net:8446 (tailnet only)
+|-- / proxy http://localhost:30100
+
 https://holdens-mac-mini.story-larch.ts.net:8447 (tailnet only)
 |-- / proxy http://localhost:30789
 
@@ -210,6 +216,9 @@ tailscale serve --https=8443 off
 
 # Stop Grafana proxy
 tailscale serve --https=8444 off
+
+# Stop LaunchFast proxy
+tailscale serve --https=8446 off
 
 # Stop Trivy Dashboard proxy
 tailscale serve --https=8448 off
@@ -244,6 +253,7 @@ Tailscale's MagicDNS automatically resolves `<hostname>.story-larch.ts.net` to t
 | ArgoCD | `https://holdens-mac-mini.story-larch.ts.net:8443` | 8443 | SSO via Authentik |
 | Grafana | `https://holdens-mac-mini.story-larch.ts.net:8444` | 8444 | SSO via Authentik |
 | Infisical | `https://holdens-mac-mini.story-larch.ts.net:8445` | 8445 | Local admin |
+| LaunchFast | `https://holdens-mac-mini.story-larch.ts.net:8446` | 8446 | SSO portal bookmark |
 | OpenClaw | `https://holdens-mac-mini.story-larch.ts.net:8447` | 8447 | SSO portal bookmark |
 | Trivy Dashboard | `https://holdens-mac-mini.story-larch.ts.net:8448` | 8448 | SSO portal bookmark |
 | Vikunja | `https://holdens-mac-mini.story-larch.ts.net:8449` | 8449 | SSO via Authentik |
@@ -279,7 +289,7 @@ flowchart TD
 
     subgraph tailnet["Tailscale Tailnet (story-larch)"]
         subgraph mac["Mac mini M4\n100.77.144.4"]
-            TS["tailscale serve\n:443, :8443, :8444, :8445, :8447, :8448, :8449"]
+            TS["tailscale serve\n:443, :8443, :8444, :8445, :8446, :8447, :8448, :8449"]
 
             subgraph orb["OrbStack Kubernetes"]
                 subgraph authentik["authentik ns"]

--- a/k8s/apps/authentik/README.md
+++ b/k8s/apps/authentik/README.md
@@ -131,7 +131,7 @@ tailscale serve --bg http://localhost:30500
 | Infisical | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8445` |
 | OpenClaw | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8447` |
 | Trivy Dashboard | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8448` |
-| LaunchFast | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8444` |
+| LaunchFast | Bookmark | `https://holdens-mac-mini.story-larch.ts.net:8446` |
 | Vikunja | OIDC (`auth.openid`) | `https://holdens-mac-mini.story-larch.ts.net:8449` |
 | Homelab Docs | Bookmark | `https://holdennguyen.github.io/homelab` |
 

--- a/k8s/apps/authentik/blueprints-configmap.yaml
+++ b/k8s/apps/authentik/blueprints-configmap.yaml
@@ -63,7 +63,7 @@ data:
         attrs:
           name: LaunchFast
           group: Development
-          meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8444
+          meta_launch_url: https://holdens-mac-mini.story-larch.ts.net:8446
           meta_icon: https://api.iconify.design/mdi/rocket-launch-outline.svg?color=%236c63ff
           meta_description: Modern Startup Scaffolding CLI
           meta_publisher: Homelab

--- a/k8s/apps/launchfast/README.md
+++ b/k8s/apps/launchfast/README.md
@@ -15,7 +15,7 @@ flowchart LR
         CM --> Deploy
         Deploy --> Svc
     end
-    Tailscale["Tailscale Serve\nhttps://:8444"] --> Svc
+    Tailscale["Tailscale Serve\nhttps://:8446"] --> Svc
 ```
 
 ## Directory Contents
@@ -110,10 +110,10 @@ Visit `https://holdens-mac-mini.story-larch.ts.net` and click the LaunchFast til
 **Via Tailscale Serve (direct):**
 
 ```bash
-tailscale serve --bg --https 8444 http://localhost:30100
+tailscale serve --bg --https 8446 http://localhost:30100
 ```
 
-Then visit `https://holdens-mac-mini.story-larch.ts.net:8444` from any Tailscale device.
+Then visit `https://holdens-mac-mini.story-larch.ts.net:8446` from any Tailscale device.
 
 **Via direct NodePort:**
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -40,6 +40,7 @@ output "next_steps" {
          tailscale serve --bg --https 8443 http://localhost:30080   # ArgoCD
          tailscale serve --bg --https 8444 http://localhost:30090   # Grafana
          tailscale serve --bg --https 8445 http://localhost:30445   # Infisical
+         tailscale serve --bg --https 8446 http://localhost:30100   # LaunchFast
          tailscale serve --bg --https 8447 http://localhost:30789   # OpenClaw
   EOT
 }


### PR DESCRIPTION
## Summary

- Fix LaunchFast Authentik bookmark opening Grafana instead of LaunchFast — port 8444 was already assigned to Grafana
- Reassign LaunchFast to Tailscale Serve port **8446** across all references
- Add `tailscale serve --bg --https 8446 http://localhost:30100` to all canonical bootstrap/networking docs

## Files Changed

| File | Change |
|---|---|
| `k8s/apps/authentik/blueprints-configmap.yaml` | `meta_launch_url` 8444→8446 |
| `k8s/apps/authentik/README.md` | Application Inventory table 8444→8446 |
| `k8s/apps/launchfast/README.md` | Mermaid diagram, serve command, access URL 8444→8446 |
| `README.md` | Serve commands + access URLs list |
| `docs/infrastructure/networking.md` | Serve commands, status output, manage serve, access URLs table, topology diagram |
| `docs/getting-started/bootstrap.md` | Serve commands, expected status output, access URLs table |
| `terraform/outputs.tf` | Post-apply next_steps serve commands |

## Post-Merge Steps

1. Sync ArgoCD manually (blueprint ConfigMap update)
2. Restart Authentik worker: `kubectl rollout restart deployment authentik-worker -n authentik`
3. Tailscale Serve for port 8446 already running

## Test Plan

- [ ] LaunchFast tile in Authentik portal opens `https://holdens-mac-mini.story-larch.ts.net:8446` (not 8444)
- [ ] Grafana tile still opens correctly on 8444


Made with [Cursor](https://cursor.com)