### PR TITLE
feat: Discord channel isolation with AI daily briefing

### DIFF
--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -28,7 +28,7 @@ flowchart TD
     end
 
     subgraph infisical["Infisical (homelab / prod)"]
-        InfisicalSecrets["OPENCLAW_GATEWAY_TOKEN\nOPENROUTER_API_KEY\nGEMINI_API_KEY\nGITHUB_TOKEN\nDISCORD_BOT_TOKEN\nVIKUNJA_API_TOKEN\nDISCORD_WEBHOOK_VIKUNJA"]
+        InfisicalSecrets["OPENCLAW_GATEWAY_TOKEN\nOPENROUTER_API_KEY\nGEMINI_API_KEY\nGITHUB_TOKEN\nDISCORD_BOT_TOKEN\nVIKUNJA_API_TOKEN\nDISCORD_WEBHOOK_VIKUNJA\nDISCORD_WEBHOOK_ALERTS"]
     end
 
     subgraph providers["AI Model Providers"]
@@ -232,7 +232,8 @@ Add the following secrets to Infisical under **homelab / prod**:
 | `GITHUB_TOKEN` | GitHub PAT (Fine-grained) with repo scope for `holdennguyen/homelab` | Yes (for git workflow) |
 | `DISCORD_BOT_TOKEN` | From [Discord Developer Portal](https://discord.com/developers/applications) → Bot → Reset Token | Yes (for Discord chat channel) |
 | `VIKUNJA_API_TOKEN` | From Vikunja UI → Settings → API Tokens → Create Token | Yes (for Vikunja task management integration) |
-| `DISCORD_WEBHOOK_VIKUNJA` | From Discord channel → Edit Channel → Integrations → Webhooks → New Webhook | Yes (for Vikunja task notifications to Discord) |
+| `DISCORD_WEBHOOK_VIKUNJA` | From Discord `#daily-briefing` channel → Integrations → Webhooks | Yes (for daily briefing + task notifications) |
+| `DISCORD_WEBHOOK_ALERTS` | From Discord `#alerts` channel → Integrations → Webhooks | Yes (for cluster health alerts + incident notifications) |
 
 After adding secrets, ESO syncs them into the `openclaw-secret` K8s Secret within the `refreshInterval` (1 hour), or force an immediate sync:
 
@@ -346,7 +347,51 @@ Access from any Tailscale device: `https://holdens-mac-mini.story-larch.ts.net:8
 
 ## Discord Chat Channel
 
-OpenClaw connects to Discord as a chat channel, allowing users to converse with homelab agents from any Discord client (mobile, desktop, or web). Messages sent in a Discord channel or DM are routed to the default `homelab-admin` orchestrator agent, which can delegate to sub-agents as needed.
+OpenClaw connects to Discord as a chat channel, allowing users to converse with homelab agents from any Discord client (mobile, desktop, or web). The Discord server uses a **multi-channel architecture** with per-channel skill isolation, so each channel has a focused purpose.
+
+### Channel Architecture
+
+```mermaid
+flowchart TD
+    subgraph discord["Discord Server: holden.nguyen's homelab"]
+        subgraph category["Homelab (Category)"]
+            General["#general\nFull homelab admin"]
+            Briefing["#daily-briefing\nWeather + tasks + lifestyle"]
+            Alerts["#alerts\nCluster health + incidents"]
+        end
+    end
+
+    subgraph openclaw["OpenClaw Pod"]
+        HA["homelab-admin agent"]
+    end
+
+    subgraph skills_gen["#general skills"]
+        SG1["homelab-admin"] & SG2["gitops"] & SG3["secret-management"] & SG4["incident-response"] & SG5["vikunja"] & SG6["daily-briefing"] & SG7["weather"]
+    end
+
+    subgraph skills_brief["#daily-briefing skills"]
+        SB1["vikunja"] & SB2["daily-briefing"] & SB3["weather"]
+    end
+
+    subgraph skills_alert["#alerts skills"]
+        SA1["homelab-admin"] & SA2["incident-response"]
+    end
+
+    General --> HA
+    Briefing --> HA
+    Alerts --> HA
+    HA --> skills_gen
+    HA --> skills_brief
+    HA --> skills_alert
+```
+
+| Channel | Purpose | Skills | Webhook |
+|---|---|---|---|
+| `#general` | Full homelab admin — cluster ops, GitOps, troubleshooting, general chat | All 7 skills | — |
+| `#daily-briefing` | Personal assistant — morning briefing, task management, weather, lifestyle advice | `vikunja`, `daily-briefing`, `weather` | `DISCORD_WEBHOOK_VIKUNJA` |
+| `#alerts` | Cluster health — incident alerts, pod failures, ArgoCD sync issues | `homelab-admin`, `incident-response` | `DISCORD_WEBHOOK_ALERTS` |
+
+Each channel has a system prompt that constrains the agent's behavior to the channel's purpose. The `groupPolicy` is set to `allowlist` so the bot only responds in explicitly configured channels.
 
 ### How It Works
 
@@ -359,12 +404,19 @@ sequenceDiagram
 
     User->>Discord: Send message in channel / DM
     Discord->>OC: Gateway event (WebSocket)
-    OC->>OC: Route to default agent (homelab-admin)
+    OC->>OC: Route to homelab-admin with channel-scoped skills
     OC->>Model: LLM request
     Model-->>OC: Response
     OC->>Discord: Send reply to channel / DM
     Discord-->>User: Bot message appears
 ```
+
+### Automated Notifications
+
+| Notification | Channel | Schedule | Mechanism |
+|---|---|---|---|
+| Daily briefing (weather + tasks + tips) | `#daily-briefing` | 6:30 AM ICT daily | OpenClaw cron → `DISCORD_WEBHOOK_VIKUNJA` |
+| Cluster alerts | `#alerts` | On incident detection | Agent → `DISCORD_WEBHOOK_ALERTS` |
 
 ### Discord Concepts (quick primer)
 
@@ -495,7 +547,8 @@ Discord requires two config sections in `openclaw.json`:
 | Key | Value | Purpose |
 |---|---|---|
 | `enabled` | `true` | Activate the Discord channel on startup |
-| `groupPolicy` | `"open"` | Allow messages from all guild channels (mention-gating still applies) |
+| `groupPolicy` | `"allowlist"` | Only respond in explicitly configured guild channels |
+| `guilds.<id>.channels.<id>` | Per-channel config | Allowlist, system prompt, and skill scope per channel |
 
 **Plugin entry** (`plugins.entries.discord`):
 
@@ -507,12 +560,20 @@ The plugin entry is required because the ConfigMap is mounted read-only. OpenCla
 
 The bot token is resolved from the `DISCORD_BOT_TOKEN` environment variable (injected via ESO from Infisical). No token is stored in the config file.
 
+**Per-channel guild config** (under `channels.discord.guilds.<guildId>.channels.<channelId>`):
+
+| Key | Type | Purpose |
+|---|---|---|
+| `allow` | `boolean` | Whether the bot responds in this channel |
+| `systemPrompt` | `string` | Channel-specific behavior instructions |
+| `skills` | `string[]` | Restrict which skills the agent can use in this channel |
+
 **Available group policies:**
 
 | Policy | Behavior |
 |---|---|
-| `"open"` | Bot responds in any channel it can see (when mentioned). This is the current setting. |
-| `"allowlist"` | Bot only responds in channels explicitly listed in `channels.discord.guilds.<id>.channels` |
+| `"open"` | Bot responds in any channel it can see (when mentioned) |
+| `"allowlist"` | Bot only responds in channels explicitly listed in `channels.discord.guilds.<id>.channels`. **This is the current setting.** |
 | `"disabled"` | Block all guild channel messages; only DMs work |
 
 ## Running CLI Commands Inside the Pod
@@ -652,7 +713,7 @@ The `openclaw.json` config (in `configmap.yaml`) contains these key settings:
 | `agents.defaults.subagents` | `maxSpawnDepth` | `2` | Orchestrator → sub-agent → leaf worker |
 | `agents.list[].subagents` | `allowAgents` | Per-agent list | Controls which agents each agent can spawn — only the orchestrator has non-empty lists |
 | `channels.discord` | `enabled` | `true` | Connect to Discord on startup using `DISCORD_BOT_TOKEN` env var |
-| `channels.discord` | `groupPolicy` | `"open"` | Respond in any guild channel the bot can see (mention required) |
+| `channels.discord` | `groupPolicy` | `"allowlist"` | Only respond in explicitly configured channels |
 | `plugins.entries.discord` | `enabled` | `true` | Load Discord extension plugin (required for read-only ConfigMap) |
 
 ## Multi-Agent & Skills Architecture
@@ -690,9 +751,11 @@ flowchart TD
         S7["qa-tester"]
         S8["incident-response"]
         S9["vikunja"]
+        S10["daily-briefing"]
+        S11["weather"]
     end
 
-    HA --> S1 & S5 & S6 & S8 & S9
+    HA --> S1 & S5 & S6 & S8 & S9 & S10 & S11
     DS --> S2 & S5 & S6 & S8
     SE --> S3 & S5
     SA --> S4 & S5 & S6
@@ -703,7 +766,7 @@ Each agent has a `skills` allowlist in the configmap that restricts which skills
 
 | Agent | Assigned Skills |
 |---|---|
-| `homelab-admin` | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `vikunja` |
+| `homelab-admin` | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `vikunja`, `daily-briefing`, `weather` |
 | `devops-sre` | `devops-sre`, `gitops`, `secret-management`, `incident-response` |
 | `software-engineer` | `software-engineer`, `gitops` |
 | `security-analyst` | `security-analyst`, `gitops`, `secret-management` |
@@ -747,6 +810,8 @@ Homelab-specific skills live in `skills/` at the repo root and are mounted into 
 | `incident-response` | Incident triage, rollback procedures, pre-merge validation, post-incident documentation |
 | `secret-management` | Infisical → ESO → K8s pipeline operations |
 | `vikunja` | Vikunja task management API — create, query, update, complete tasks; Discord notifications |
+| `daily-briefing` | AI-powered morning briefing — weather, tasks, cluster health, contextual lifestyle advice |
+| `weather` | Real-time weather via Open-Meteo and wttr.in (no API key required) |
 | `common/Documentation` | Standardized documentation generation |
 
 Skills follow the [AgentSkills](https://agentskills.io) format with OpenClaw-compatible `SKILL.md` frontmatter.

--- a/k8s/apps/openclaw/configmap.yaml
+++ b/k8s/apps/openclaw/configmap.yaml
@@ -21,7 +21,7 @@ data:
             "default": true,
             "workspace": "/data/workspaces/homelab-admin",
             "model": { "primary": "openrouter/stepfun/step-3.5-flash:free", "fallbacks": ["google/gemini-2.5-pro"] },
-            "skills": ["homelab-admin", "gitops", "secret-management", "incident-response", "vikunja"],
+            "skills": ["homelab-admin", "gitops", "secret-management", "incident-response", "vikunja", "daily-briefing", "weather"],
             "subagents": {
               "allowAgents": ["devops-sre", "software-engineer", "security-analyst", "qa-tester"]
             }
@@ -83,7 +83,30 @@ data:
       "channels": {
         "discord": {
           "enabled": true,
-          "groupPolicy": "open"
+          "groupPolicy": "allowlist",
+          "guilds": {
+            "1475145705847914700": {
+              "slug": "homelab",
+              "requireMention": false,
+              "channels": {
+                "1475145706875654359": {
+                  "allow": true,
+                  "systemPrompt": "This is the #general channel. You are the homelab admin assistant. Handle any homelab question — cluster ops, GitOps, troubleshooting, service management, and general conversation. Use all available skills.",
+                  "skills": ["homelab-admin", "gitops", "secret-management", "incident-response", "vikunja", "daily-briefing", "weather"]
+                },
+                "1476238467510829148": {
+                  "allow": true,
+                  "systemPrompt": "This is the #daily-briefing channel. Focus exclusively on personal assistant tasks: daily routine management, task tracking via Vikunja, weather updates, and lifestyle advice. Do NOT discuss cluster operations or infrastructure here. Be warm, concise, and actionable.",
+                  "skills": ["vikunja", "daily-briefing", "weather"]
+                },
+                "1476238496799789118": {
+                  "allow": true,
+                  "systemPrompt": "This is the #alerts channel. Focus exclusively on cluster health monitoring, incident response, and operational alerts. Be concise and action-oriented. Only discuss infrastructure issues, pod health, ArgoCD sync problems, and service degradation.",
+                  "skills": ["homelab-admin", "incident-response"]
+                }
+              }
+            }
+          }
         }
       },
       "skills": {

--- a/k8s/apps/openclaw/deployment.yaml
+++ b/k8s/apps/openclaw/deployment.yaml
@@ -106,6 +106,11 @@ spec:
                 secretKeyRef:
                   name: openclaw-secret
                   key: DISCORD_WEBHOOK_VIKUNJA
+            - name: DISCORD_WEBHOOK_ALERTS
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secret
+                  key: DISCORD_WEBHOOK_ALERTS
             - name: GIT_CONFIG_COUNT
               value: "2"
             - name: GIT_CONFIG_KEY_0

--- a/k8s/apps/openclaw/external-secret.yaml
+++ b/k8s/apps/openclaw/external-secret.yaml
@@ -33,3 +33,6 @@ spec:
     - secretKey: DISCORD_WEBHOOK_VIKUNJA
       remoteRef:
         key: DISCORD_WEBHOOK_VIKUNJA
+    - secretKey: DISCORD_WEBHOOK_ALERTS
+      remoteRef:
+        key: DISCORD_WEBHOOK_ALERTS

--- a/skills/daily-briefing/SKILL.md
+++ b/skills/daily-briefing/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: daily-briefing
+description: Compose a personalized daily briefing with real-time weather, Vikunja tasks, cluster health, and contextual lifestyle advice. Delivered to Discord as a morning digest.
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🌅",
+        "requires": { "anyBins": ["curl"] },
+      },
+  }
+---
+
+# Daily Briefing
+
+Compose and deliver a rich, personalized daily briefing to Discord. This is NOT a boring task list — it's an AI-powered morning digest that combines real-time data with contextual advice.
+
+## Philosophy
+
+Traditional reminder apps dump a static checklist. This briefing is different:
+
+- **Context-aware**: Weather conditions influence activity suggestions (e.g., "It's 34°C — hydrate extra during your workout" or "Rain expected — move your run indoors")
+- **Time-aware**: Greeting and tone adapt to the time of day
+- **Synthesized**: The agent reads multiple data sources, then composes a single coherent narrative — not separate blocks pasted together
+- **Actionable**: Every piece of information connects to a suggestion or next step
+
+## Data sources
+
+Gather these in parallel before composing the briefing:
+
+### 1. Weather (Open-Meteo — no API key)
+
+```bash
+curl -s "https://api.open-meteo.com/v1/forecast?latitude=10.82&longitude=106.63&current_weather=true&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,weathercode,uv_index_max,sunrise,sunset&hourly=temperature_2m,precipitation_probability,weathercode&timezone=Asia/Ho_Chi_Minh&forecast_days=1"
+```
+
+Location: Ho Chi Minh City (lat 10.82, lon 106.63, tz Asia/Ho_Chi_Minh).
+
+#### WMO weather code reference
+
+| Code | Meaning |
+|---|---|
+| 0 | Clear sky |
+| 1-3 | Partly cloudy / Overcast |
+| 45, 48 | Fog |
+| 51-55 | Drizzle |
+| 61-65 | Rain |
+| 66-67 | Freezing rain |
+| 71-75 | Snowfall |
+| 80-82 | Rain showers |
+| 95, 96, 99 | Thunderstorm |
+
+### 2. Tasks due today (Vikunja)
+
+The `/tasks/all` endpoint is unavailable in Vikunja v1.1.0. Fetch per-project instead:
+
+```bash
+VIKUNJA_URL="http://vikunja.vikunja.svc.cluster.local/api/v1"
+AUTH="Authorization: Bearer $VIKUNJA_API_TOKEN"
+
+# Get all project IDs
+PROJECTS=$(curl -s -H "$AUTH" "$VIKUNJA_URL/projects" | jq -r '.[].id')
+
+# For each project, get incomplete tasks
+for PID in $PROJECTS; do
+  curl -s -H "$AUTH" "$VIKUNJA_URL/projects/$PID/tasks" | jq '.[] | select(.done == false) | {id, title, due_date, priority, project_id}'
+done
+```
+
+To find overdue tasks, filter results where `due_date` is before now and after `"0001"` (unset dates use year 0001).
+
+### 3. Cluster health (quick pulse)
+
+```bash
+kubectl get pods -A --no-headers | awk '{print $4}' | sort | uniq -c | sort -rn
+kubectl get applications -n argocd --no-headers -o custom-columns='NAME:.metadata.name,HEALTH:.status.health.status,SYNC:.status.sync.status' | grep -v "Healthy.*Synced" || echo "all-healthy"
+```
+
+### 4. Date context
+
+```bash
+date -u '+%A, %B %d, %Y'
+TZ=Asia/Ho_Chi_Minh date '+%H:%M %Z'
+```
+
+## Composing the briefing
+
+After gathering all data, compose a SINGLE cohesive Discord message. Do NOT just paste raw data — synthesize it.
+
+### Structure
+
+Use the Discord webhook (`$DISCORD_WEBHOOK_VIKUNJA`) with embeds:
+
+```
+Embed 1: Daily Briefing header
+- Title: "Good morning, Holden ☀️" (or appropriate greeting for time of day)
+- Description: A 2-3 sentence opening that weaves together weather + day context
+  Example: "It's a warm Tuesday in Saigon — 32°C with overcast skies and no rain expected.
+  Perfect conditions for your morning routine. You have 3 tasks lined up today."
+
+Embed 2: Weather snapshot
+- Inline fields: Current temp, High/Low, Rain chance, UV Index, Sunrise/Sunset
+
+Embed 3: Today's tasks (if any)
+- Each task as a line with priority emoji: 🔴 urgent, 🟠 high, 🟡 medium, 🟢 low
+- Overdue tasks highlighted at the top
+
+Embed 4 (optional): Contextual tips
+- Weather-driven: "UV index is 11 — wear sunscreen if going outside"
+- Task-driven: "You have 2 overdue tasks — consider clearing those first"
+- Cluster-driven: only if something is degraded
+```
+
+### Contextual advice patterns
+
+| Condition | Advice |
+|---|---|
+| Temp > 35°C | "Extreme heat today — stay hydrated, avoid midday sun" |
+| Temp > 32°C | "Hot day — consider an early morning workout before it heats up" |
+| Rain > 60% chance | "Rain likely — have an indoor backup for outdoor plans" |
+| UV > 8 | "Very high UV — sunscreen and shade recommended" |
+| Thunderstorm codes (95-99) | "Thunderstorms expected — stay indoors during peak hours" |
+| 0 overdue, 0 today tasks | "Clean slate today! Good time to plan ahead or tackle a backlog item" |
+| Overdue tasks > 0 | "You have N overdue tasks — knocking those out first will feel great" |
+| High priority task due | "Heads up: [task name] is high priority and due today" |
+| Cluster degraded | "⚠ Cluster alert: [service] is [status] — may need attention" |
+| All systems healthy | Omit cluster section entirely (no news is good news) |
+
+### Color scheme
+
+| Section | Color (decimal) | Meaning |
+|---|---|---|
+| Header | 5814783 | Blue — informational |
+| Weather | 16760576 | Orange — warmth |
+| Tasks (all good) | 3066993 | Green |
+| Tasks (overdue) | 15158332 | Red — attention |
+| Tips | 10070709 | Light purple — advisory |
+
+### Sending the message
+
+Post to the `#daily-briefing` channel via its dedicated webhook:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" "$DISCORD_WEBHOOK_VIKUNJA" \
+  -d '<composed JSON with embeds array>'
+```
+
+Keep total embed content under 6000 characters (Discord limit).
+
+For cluster alerts, use the `#alerts` channel webhook instead:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" "$DISCORD_WEBHOOK_ALERTS" \
+  -d '<alert embed JSON>'
+```
+
+## Cron schedule
+
+The briefing should run daily at **6:30 AM ICT (23:30 UTC previous day)**.
+
+Cron expression: `30 23 * * *` (UTC) which is 6:30 AM ICT (UTC+7).
+
+## Error handling
+
+If any data source fails, compose the briefing with whatever data IS available. Never skip the entire briefing because one API timed out. Mention the gap: "Weather data unavailable — check wttr.in manually."

--- a/skills/incident-response/SKILL.md
+++ b/skills/incident-response/SKILL.md
@@ -24,6 +24,24 @@ Procedures for detecting, triaging, rolling back, and documenting incidents in t
 | **SEV-3** | Non-critical service degraded, workaround exists | Within 1 hour |
 | **SEV-4** | Cosmetic issue, no user impact | Next available cycle |
 
+## Discord Alerts
+
+When detecting incidents or cluster degradation, send alerts to the `#alerts` Discord channel via the dedicated webhook:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" "$DISCORD_WEBHOOK_ALERTS" \
+  -d '{
+    "embeds": [{
+      "title": "⚠ Cluster Alert — SEV-N",
+      "description": "**Service:** <name>\n**Status:** <CrashLoopBackOff|Degraded|...>\n**Namespace:** <ns>\n**Action:** <investigating|rolling back|resolved>",
+      "color": 15158332,
+      "footer": {"text": "Homelab Incident Response"}
+    }]
+  }'
+```
+
+Color codes: SEV-1/2 = `15158332` (red), SEV-3 = `15105570` (orange), SEV-4 = `16776960` (yellow), Resolved = `3066993` (green).
+
 ## Phase 1: Detection & Triage
 
 When a deployment causes issues, run this triage sequence to assess blast radius:

--- a/skills/vikunja/SKILL.md
+++ b/skills/vikunja/SKILL.md
@@ -51,17 +51,24 @@ curl -s -H "$AUTH" "$VIKUNJA_URL/projects/<PROJECT_ID>/tasks" | jq '.[] | {id, t
 
 ### Get tasks due today
 
+Fetch tasks from each project and filter by due date (the `/tasks/all` endpoint is unavailable in Vikunja v1.1.0):
+
 ```bash
-TODAY=$(date -u +%Y-%m-%dT00:00:00Z)
-TOMORROW=$(date -u -v+1d +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u -d "+1 day" +%Y-%m-%dT00:00:00Z)
-curl -s -H "$AUTH" "$VIKUNJA_URL/tasks/all?filter=due_date>$TODAY&&due_date<$TOMORROW" | jq '.[] | {id, title, due_date, project_id}'
+PROJECTS=$(curl -s -H "$AUTH" "$VIKUNJA_URL/projects" | jq -r '.[].id')
+TODAY=$(date -u +%Y-%m-%d)
+for PID in $PROJECTS; do
+  curl -s -H "$AUTH" "$VIKUNJA_URL/projects/$PID/tasks" | jq --arg today "$TODAY" '.[] | select(.done == false and (.due_date[:10] == $today)) | {id, title, due_date, priority, project_id}'
+done
 ```
 
 ### Get overdue tasks
 
 ```bash
+PROJECTS=$(curl -s -H "$AUTH" "$VIKUNJA_URL/projects" | jq -r '.[].id')
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-curl -s -H "$AUTH" "$VIKUNJA_URL/tasks/all?filter=due_date<$NOW&&done=false" | jq '.[] | {id, title, due_date, project_id}'
+for PID in $PROJECTS; do
+  curl -s -H "$AUTH" "$VIKUNJA_URL/projects/$PID/tasks" | jq --arg now "$NOW" '.[] | select(.done == false and .due_date > "0001" and .due_date < $now) | {id, title, due_date, priority, project_id}'
+done
 ```
 
 ### Create a task
@@ -108,8 +115,14 @@ curl -s -X DELETE -H "$AUTH" "$VIKUNJA_URL/tasks/<TASK_ID>"
 
 ### Search tasks
 
+Search across all projects by iterating:
+
 ```bash
-curl -s -H "$AUTH" "$VIKUNJA_URL/tasks/all?s=search+term" | jq '.[] | {id, title, done, project_id}'
+TERM="search term"
+PROJECTS=$(curl -s -H "$AUTH" "$VIKUNJA_URL/projects" | jq -r '.[].id')
+for PID in $PROJECTS; do
+  curl -s -H "$AUTH" "$VIKUNJA_URL/projects/$PID/tasks" | jq --arg term "$TERM" '[.[] | select(.title | ascii_downcase | contains($term | ascii_downcase))] | .[] | {id, title, done, project_id}'
+done
 ```
 
 ## Label operations
@@ -177,9 +190,15 @@ curl -s -X POST -H "Content-Type: application/json" \
 ### Send daily summary to Discord
 
 ```bash
-TODAY=$(date -u +%Y-%m-%dT00:00:00Z)
-TOMORROW=$(date -u -v+1d +%Y-%m-%dT00:00:00Z 2>/dev/null || date -u -d "+1 day" +%Y-%m-%dT00:00:00Z)
-TASKS=$(curl -s -H "$AUTH" "$VIKUNJA_URL/tasks/all?filter=due_date>$TODAY&&due_date<$TOMORROW&&done=false" | jq -r '.[] | "• \(.title) (priority: \(.priority))"')
+TODAY=$(date -u +%Y-%m-%d)
+PROJECTS=$(curl -s -H "$AUTH" "$VIKUNJA_URL/projects" | jq -r '.[].id')
+TASKS=""
+for PID in $PROJECTS; do
+  PROJ_TASKS=$(curl -s -H "$AUTH" "$VIKUNJA_URL/projects/$PID/tasks" | jq -r --arg today "$TODAY" '.[] | select(.done == false and (.due_date[:10] == $today)) | "• \(.title) (priority: \(.priority))"')
+  if [ -n "$PROJ_TASKS" ]; then
+    TASKS="${TASKS}${PROJ_TASKS}\n"
+  fi
+done
 if [ -n "$TASKS" ]; then
   curl -s -X POST -H "Content-Type: application/json" \
     "$DISCORD_WEBHOOK_VIKUNJA" \


### PR DESCRIPTION
## Summary

- Add multi-channel Discord architecture: `#general` (full admin), `#daily-briefing` (personal assistant), `#alerts` (cluster health)
- Each channel has per-channel skill scoping and system prompts via OpenClaw's guild allowlist config (`groupPolicy: allowlist`)
- New `daily-briefing` skill: AI-powered morning digest combining real-time weather (Open-Meteo), Vikunja tasks, and cluster health into contextual lifestyle advice
- OpenClaw cron job delivers the briefing daily at 6:30 AM ICT to `#daily-briefing` via webhook
- Fix Vikunja `/tasks/all` endpoint (broken in v1.1.0) — replaced with per-project task fetching
- Add `DISCORD_WEBHOOK_ALERTS` secret for incident notifications to `#alerts` channel

### Discord Channel Structure

| Channel | Skills | Purpose |
|---|---|---|
| `#general` | all 7 | Full homelab admin chat |
| `#daily-briefing` | vikunja, daily-briefing, weather | Personal assistant, tasks, weather |
| `#alerts` | homelab-admin, incident-response | Cluster health alerts |

### Infisical Secrets (already added)

- `DISCORD_WEBHOOK_VIKUNJA` — updated to `#daily-briefing` channel webhook
- `DISCORD_WEBHOOK_ALERTS` — new, for `#alerts` channel webhook

## Test plan

- [ ] Verify ArgoCD syncs all manifests (configmap, deployment, external-secret)
- [ ] Verify ESO syncs both webhook secrets
- [ ] Verify OpenClaw pod starts with new env vars
- [ ] Send message in `#general` — agent responds with full skill set
- [ ] Send message in `#daily-briefing` — agent responds with personal assistant focus
- [ ] Send message in `#alerts` — agent responds with cluster health focus
- [ ] Trigger daily briefing cron job — verify Discord embed in `#daily-briefing`
- [ ] Send test alert — verify Discord embed in `#alerts`

Made with [Cursor](https://cursor.com)