### PR TITLE
feat: interactive schedule management via Discord

### DIFF
--- a/k8s/apps/openclaw/configmap.yaml
+++ b/k8s/apps/openclaw/configmap.yaml
@@ -96,7 +96,7 @@ data:
                 },
                 "1476238467510829148": {
                   "allow": true,
-                  "systemPrompt": "This is the #daily-briefing channel. Focus exclusively on personal assistant tasks: daily routine management, task tracking via Vikunja, weather updates, and lifestyle advice. Do NOT discuss cluster operations or infrastructure here. Be warm, concise, and actionable.",
+                  "systemPrompt": "This is the #daily-briefing channel — Holden's personal schedule assistant.\n\nYou can:\n- Show today's schedule from Vikunja (project 2 = Daily Routine)\n- Add new tasks/habits: review the current schedule, find gaps, suggest optimal time slots, confirm before creating\n- Reschedule or swap tasks: move things around, handle conflicts, offer alternatives\n- Skip or complete tasks for today without breaking recurring patterns\n- Answer lifestyle questions: weather-aware fitness advice, nutrition nudges, sleep coaching\n\nAlways fetch the current schedule before suggesting changes. Never place tasks during sleep prep (9 PM+) or remove health-critical tasks (hydration, eye breaks, meals). Default to project 2 for all task operations. Be warm, concise, and proactive — suggest improvements, don't just execute commands.\n\nDo NOT discuss cluster operations or infrastructure here.",
                   "skills": ["vikunja", "daily-briefing", "weather"]
                 },
                 "1476238496799789118": {

--- a/skills/vikunja/SKILL.md
+++ b/skills/vikunja/SKILL.md
@@ -213,6 +213,123 @@ if [ -n "$TASKS" ]; then
 fi
 ```
 
+## Daily routine project
+
+Project **ID 2** is the daily routine project. It contains ~21 recurring tasks that form Holden's personalized health routine. Always use project 2 when creating, updating, or querying routine-related tasks.
+
+### Time blocks
+
+The routine is structured in blocks. When the user wants to add something, the agent must know which block it falls into and whether there's a gap:
+
+| Block | Time range | Purpose |
+|---|---|---|
+| Morning | 5:30 – 7:30 AM | Wake, stretch, exercise, breakfast, reading |
+| Work | 8:00 AM – 5:00 PM | SRE work + health breaks at 10:00 AM, 12:00 PM, 3:00 PM |
+| Fitness | 5:30 – 6:30 PM | Strength (M/W/F) or cardio (Tu/Th) |
+| Dinner | 6:30 – 7:30 PM | Meal (finish by 7:30 PM) |
+| Creative | 7:30 – 8:30 PM | Piano (M/W/F) or guitar (Tu/Th), then singing |
+| Wind-down | 8:30 – 9:30 PM | Reading, sleep prep, lights out |
+
+### Fetch today's schedule
+
+```bash
+VIKUNJA_URL="http://vikunja.vikunja.svc.cluster.local/api/v1"
+AUTH="Authorization: Bearer $VIKUNJA_API_TOKEN"
+TODAY=$(TZ=Asia/Ho_Chi_Minh date +%Y-%m-%d)
+curl -s -H "$AUTH" "$VIKUNJA_URL/projects/2/tasks?sort_by=due_date&order_by=asc" \
+  | jq --arg today "$TODAY" '[.[] | select(.done == false and (.due_date[:10] == $today))] | sort_by(.due_date) | .[] | {id, title, due_date, priority, repeat_after}'
+```
+
+### Find available gaps
+
+After fetching the schedule, identify gaps between tasks. Available slots for new activities:
+
+| Preferred slot | When | Good for |
+|---|---|---|
+| 7:30 – 8:00 AM | After breakfast, before work | Quick personal tasks, journaling |
+| 12:30 – 1:00 PM | After post-lunch walk | Short errands, calls |
+| 5:00 – 5:30 PM | After work, before workout | Transition tasks, quick errands |
+| 8:15 – 8:30 PM | Between singing and reading | Flexible buffer |
+
+**Never suggest placing tasks during**: sleep prep (9:00–9:30 PM), lights-out (after 9:30 PM), or within the workout block (5:30–6:30 PM) unless it replaces the workout.
+
+## Schedule-aware task management
+
+When the user asks to add something to their schedule via Discord, follow this workflow:
+
+### Step 1: Understand the request
+
+Parse what the user wants. Examples:
+- "add meditation to my routine" → new recurring task
+- "I want to learn Japanese" → needs time slot suggestion
+- "move guitar to Saturday" → reschedule existing task
+- "remind me to call the dentist tomorrow at 2 PM" → one-time task
+
+### Step 2: Review current schedule
+
+Always fetch the current day's tasks before suggesting placement. Show the user what's already scheduled around the proposed time.
+
+### Step 3: Suggest optimal placement
+
+Based on the request type:
+
+| Request | Suggestion logic |
+|---|---|
+| New daily habit (5–15 min) | Find the nearest gap in the appropriate block. Short habits go in morning or wind-down. |
+| New skill/hobby (30+ min) | Suggest the creative block (7:30–8:30 PM) or weekend afternoons. Check for conflicts with piano/guitar rotation. |
+| One-time errand/appointment | Place during work breaks (10 AM, 12:30 PM, 3 PM) or the 5:00–5:30 PM buffer. |
+| Workout change | Replace the existing fitness block entry for that day. Warn about rest day impact. |
+| Social/event | Evening slots may conflict with creative time — offer trade-offs ("Skip guitar tonight to make room?"). |
+
+### Step 4: Confirm and create
+
+Present the suggestion to the user with context:
+```
+"You currently have piano at 7:30 PM and singing at 8:00 PM.
+I can slot meditation in at 8:15 PM (15 min) — right between singing and your evening reading at 8:30 PM.
+Want me to add it?"
+```
+
+Only create/update the task after user confirmation.
+
+### Step 5: Notify on change
+
+After creating or updating a task, post a confirmation embed to Discord:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" "$DISCORD_WEBHOOK_VIKUNJA" \
+  -d '{
+    "embeds": [{
+      "title": "📅 Schedule Updated",
+      "description": "**Meditation (15 min)** added at 8:15 PM daily\nSlotted between singing and evening reading",
+      "color": 3066993,
+      "footer": {"text": "Vikunja • Daily Routine"}
+    }]
+  }'
+```
+
+### Handling conflicts
+
+If the requested time overlaps with an existing task:
+
+1. **Show the conflict**: "That slot is taken by [task] at [time]"
+2. **Offer alternatives**: Suggest 2–3 nearby gaps
+3. **Offer to swap**: "I can move [existing task] to [new time] to make room — want me to?"
+4. **Respect health priorities**: Never suggest removing nutrition, hydration, eye breaks, or sleep prep tasks. These are non-negotiable.
+
+### Rescheduling tasks
+
+To move a task to a different time:
+
+```bash
+# Update the due_date to the new time
+curl -s -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$VIKUNJA_URL/tasks/<TASK_ID>" \
+  -d '{"due_date": "2026-02-26T20:15:00Z"}'
+```
+
+When rescheduling recurring tasks, note that changing `due_date` affects only the current occurrence — the `repeat_after` interval stays the same.
+
 ## Discord command patterns
 
 When a user asks about tasks in Discord (or any channel), interpret their intent and execute the appropriate API call. Common patterns:
@@ -222,10 +339,17 @@ When a user asks about tasks in Discord (or any channel), interpret their intent
 | "add a todo: buy groceries" | Create task in default project |
 | "what's due today?" | List tasks due today |
 | "show my tasks" / "todo list" | List all incomplete tasks |
+| "show my schedule" / "what's my day look like?" | Fetch today's routine from project 2, display in time order |
 | "complete task 42" / "done with task 42" | Mark task as done |
 | "what's overdue?" | List overdue tasks |
 | "search tasks for deployment" | Search tasks by keyword |
 | "add todo: fix CI due Friday priority high" | Create task with due date and priority |
+| "add meditation to my routine" | Review schedule → suggest slot → confirm → create recurring task in project 2 |
+| "move piano to 8 PM" | Find the piano task → reschedule → confirm |
+| "skip workout today" | Mark today's workout as done (skip) without deleting the recurring task |
+| "I have a dentist appointment Thursday at 2 PM" | Create one-time task in project 2 at the requested time |
+| "what can I fit in after work?" | Show 5:00–5:30 PM gap and any other evening availability |
+| "change my morning walk to 6:30" | Update the recurring walk task's due_date |
 
 ### Parsing natural language due dates
 
@@ -238,12 +362,16 @@ Convert relative dates before API calls:
 | "Friday" / "next Friday" | Next occurrence of that weekday |
 | "next week" | Monday of next week |
 | "in 3 days" | Current date + 3 days |
+| "after work" | 5:00 PM on the relevant day |
+| "before bed" | 8:30 PM (before sleep prep at 9:00 PM) |
+| "morning" | 7:30 AM (post-breakfast gap) |
+| "lunch break" | 12:30 PM |
 
 Use `date` commands to compute the ISO 8601 timestamp for the `due_date` field.
 
 ### Default project
 
-If the user doesn't specify a project, list projects first and use the first available one. Cache the project ID during the session to avoid repeated lookups.
+When the user is in the `#daily-briefing` channel, default to **project 2** (Daily Routine) for all task operations. In other channels, list projects and use the first available one unless specified.
 
 ## Webhook setup (Vikunja → Discord)
 


### PR DESCRIPTION
## Summary

- Added schedule-aware task management to the `vikunja` skill — the agent now understands the daily routine structure (project 2, time blocks, gaps), can review the current schedule before suggesting placement, handles conflicts, and confirms with the user before creating/updating tasks
- Updated `#daily-briefing` channel system prompt to define the agent as a personal schedule assistant with explicit capabilities: add tasks, reschedule, skip, swap, and lifestyle advice
- Added Discord command patterns for schedule interactions: "show my schedule", "add meditation to my routine", "skip workout today", "what can I fit in after work?", etc.
- Added natural language time parsing for schedule context: "after work" → 5:00 PM, "before bed" → 8:30 PM, "morning" → 7:30 AM

## Changes

### `skills/vikunja/SKILL.md`
- New **Daily routine project** section: documents project 2, time blocks, schedule fetch query, available gap slots
- New **Schedule-aware task management** section: 5-step workflow (understand → review → suggest → confirm → notify), conflict handling, rescheduling API
- Expanded **Discord command patterns** with 6 new schedule-specific patterns
- Extended natural language date parsing with time-of-day shortcuts

### `k8s/apps/openclaw/configmap.yaml`
- Updated `#daily-briefing` channel `systemPrompt` to explicitly define the agent's schedule management capabilities and guardrails (no tasks during sleep prep, never remove health-critical tasks)

## Test plan

- [ ] Verify ArgoCD syncs both configmap and skill changes after merge
- [ ] In `#daily-briefing`, ask "show my schedule" — agent should fetch and display today's routine
- [ ] Ask "add meditation to my routine" — agent should review schedule, suggest a gap (e.g., 8:15 PM), and confirm before creating
- [ ] Ask "move guitar to Saturday" — agent should identify the conflict and offer alternatives
- [ ] Ask "skip workout today" — agent should mark done without deleting the recurrence


Made with [Cursor](https://cursor.com)