### PR TITLE
docs: comprehensive documentation for daily routine, journal, and schedule management

### DIFF
--- a/.doc-manifest.yml
+++ b/.doc-manifest.yml
@@ -47,6 +47,9 @@ documents:
   - doc: k8s/apps/openclaw/README.md
     sources:
       - k8s/apps/openclaw/
+      - skills/daily-briefing/
+      - skills/vikunja/
+      - skills/incident-response/
 
   - doc: k8s/apps/trivy-operator/README.md
     sources:
@@ -59,6 +62,7 @@ documents:
   - doc: k8s/apps/vikunja/README.md
     sources:
       - k8s/apps/vikunja/
+      - skills/vikunja/
 
   - doc: terraform/README.md
     sources:

--- a/docs/operations/ai-agents.md
+++ b/docs/operations/ai-agents.md
@@ -300,7 +300,7 @@ Each agent has a `skills` allowlist in the configmap that restricts which skills
 
 | Agent | Assigned Skills |
 |---|---|
-| `homelab-admin` | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `vikunja` |
+| `homelab-admin` | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `vikunja`, `daily-briefing`, `weather` |
 | `devops-sre` | `devops-sre`, `gitops`, `secret-management`, `incident-response` |
 | `software-engineer` | `software-engineer`, `gitops` |
 | `security-analyst` | `security-analyst`, `gitops`, `secret-management` |
@@ -345,7 +345,9 @@ Skills provide domain-specific knowledge and commands to agents. They live in `s
 | `gitops` | ArgoCD App of Apps pattern, sync management, mandatory git workflow reference |
 | `incident-response` | Incident triage, rollback procedures, pre-merge validation, post-incident documentation |
 | `secret-management` | Infisical → ESO → K8s pipeline operations |
-| `vikunja` | Vikunja task management API — create, query, update, complete tasks; Discord notifications |
+| `vikunja` | Vikunja task management API — CRUD tasks, Discord notifications, daily routine (project 2), journal (project 3) with check-ins/reflections, schedule-aware task management |
+| `daily-briefing` | AI morning briefing — weather, tasks, journal-driven advice, owner health profile, weekly schedule with nutrition targets |
+| `weather` | Real-time weather via Open-Meteo and wttr.in (no API key required) |
 
 ### Skill Format
 

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -388,10 +388,23 @@ flowchart TD
 | Channel | Purpose | Skills | Webhook |
 |---|---|---|---|
 | `#general` | Full homelab admin — cluster ops, GitOps, troubleshooting, general chat | All 7 skills | — |
-| `#daily-briefing` | Personal assistant — morning briefing, task management, weather, lifestyle advice | `vikunja`, `daily-briefing`, `weather` | `DISCORD_WEBHOOK_VIKUNJA` |
+| `#daily-briefing` | Personal schedule assistant & journal companion — morning briefing, interactive schedule management, task tracking, journal check-ins/reflections, weather, lifestyle advice | `vikunja`, `daily-briefing`, `weather` | `DISCORD_WEBHOOK_VIKUNJA` |
 | `#alerts` | Cluster health — incident alerts, pod failures, ArgoCD sync issues | `homelab-admin`, `incident-response` | `DISCORD_WEBHOOK_ALERTS` |
 
 Each channel has a system prompt that constrains the agent's behavior to the channel's purpose. The `groupPolicy` is set to `allowlist` so the bot only responds in explicitly configured channels.
+
+The `#daily-briefing` channel supports interactive conversations:
+
+| Interaction | Example | What happens |
+|---|---|---|
+| Morning check-in | "Slept about 6 hours, slight headache, energy 4/10" | Agent extracts structured data, saves to Journal (project 3), adjusts today's advice |
+| Evening reflection | "1. Fixed a tricky DNS issue 2. Tried a new recipe 3. Learned a guitar riff" | Agent saves to Journal (project 3), references it in tomorrow's briefing |
+| Schedule query | "Show my schedule" / "What's my day look like?" | Agent fetches today's routine tasks from project 2 |
+| Add to routine | "Add 15 min meditation after singing" | Agent reviews schedule, finds a gap, suggests placement, confirms before creating |
+| Reschedule | "Move guitar to Saturday" | Agent identifies conflicts, offers alternatives |
+| Skip task | "Skip workout today" | Marks done without breaking recurrence |
+| One-time task | "Dentist appointment Thursday 2 PM" | Creates non-recurring task at the specified time |
+| Journal lookback | "How was my sleep this week?" | Queries project 3 entries and summarizes trends |
 
 ### How It Works
 
@@ -415,8 +428,90 @@ sequenceDiagram
 
 | Notification | Channel | Schedule | Mechanism |
 |---|---|---|---|
-| Daily briefing (weather + tasks + tips) | `#daily-briefing` | 6:30 AM ICT daily | OpenClaw cron → `DISCORD_WEBHOOK_VIKUNJA` |
+| Daily briefing (weather + tasks + journal-aware advice) | `#daily-briefing` | 6:30 AM ICT daily | OpenClaw cron → `DISCORD_WEBHOOK_VIKUNJA` |
 | Cluster alerts | `#alerts` | On incident detection | Agent → `DISCORD_WEBHOOK_ALERTS` |
+
+### Daily Routine & Journal System
+
+The `#daily-briefing` channel is backed by a personalized daily routine and journal system built on Vikunja. This is not a static task list — it's a feedback loop where journal entries from today shape tomorrow's briefing.
+
+#### Vikunja Projects
+
+| Project | ID | Purpose |
+|---|---|---|
+| Inbox | 1 | Default project for ad-hoc tasks |
+| Daily Routine | 2 | 23 recurring tasks forming the daily health routine |
+| Journal | 3 | Morning check-ins and evening reflections (permanent records) |
+
+#### Daily Routine (Project 2)
+
+23 recurring tasks organized in time blocks, tailored to the owner's health goals (weight gain, sleep improvement, headache prevention):
+
+| Block | Time | Tasks |
+|---|---|---|
+| Morning | 5:30–7:30 AM | Wake + hydrate, morning check-in, stretch + breathing, walk/jog, breakfast, reading |
+| Work | 8:00 AM–5:00 PM | Mid-morning snack, eye breaks, lunch, post-lunch walk, afternoon snack, shoulder stretch |
+| Fitness | 5:30–6:30 PM | Strength training (Mon/Wed/Fri) or cardio (Tue/Thu) |
+| Dinner | 6:30–7:30 PM | Calorie-surplus meal |
+| Creative | 7:30–8:30 PM | Piano (Mon/Wed/Fri) or guitar (Tue/Thu), singing practice |
+| Wind-down | 8:30–9:30 PM | Evening reading, evening reflection, sleep prep ritual, lights out |
+| Weekend | Varies | Meal prep (Saturday), weekly health review (Sunday) |
+
+Tasks include detailed descriptions with nutrition targets (2,500–3,000 kcal/day, 120g+ protein), exercise guidance (compound lifts, zone 2 cardio), and sleep hygiene protocols.
+
+#### Journal Feedback Loop (Project 3)
+
+```mermaid
+flowchart LR
+    subgraph morning ["Morning (5:35 AM)"]
+        CheckIn["Morning Check-in\nSleep quality, energy,\nheadache, mood"]
+    end
+
+    subgraph briefing ["Briefing (6:30 AM)"]
+        Cron["Daily Briefing Cron\nReads yesterday's journal\n+ weather + tasks"]
+    end
+
+    subgraph evening ["Evening (8:50 PM)"]
+        Reflect["Evening Reflection\n3 interesting things\nfrom today"]
+    end
+
+    subgraph journal ["Vikunja Project 3 (Journal)"]
+        Entries["Journal Entries\n(permanent records)"]
+    end
+
+    CheckIn -->|"save"| Entries
+    Reflect -->|"save"| Entries
+    Entries -->|"yesterday's data"| Cron
+    Cron -->|"personalized advice"| morning
+```
+
+**Morning check-in** (5:35 AM): The user shares how they're feeling in `#daily-briefing`. The agent extracts structured data (sleep quality 1–10, energy 1–10, headache severity, mood) and saves it to project 3 with the `morning-checkin` label. This immediately adjusts today's advice — e.g., poor sleep triggers a lighter workout suggestion.
+
+**Evening reflection** (8:50 PM): The user shares 3 interesting things from the day. The agent saves them to project 3 with the `evening-reflection` label. Tomorrow's briefing references these — calling back wins, acknowledging challenges.
+
+**Daily briefing personalization**: The 6:30 AM cron briefing reads yesterday's journal entries and adjusts:
+
+| Yesterday's journal | Today's adjustment |
+|---|---|
+| Sleep quality < 5 | Suggest lighter workout, extra hydration |
+| Headache reported | Emphasize water (3L+), shorter eye break intervals |
+| Low energy | Stress all 5 meals, no skipping snacks |
+| Stressful mood | Lean into music session as a reset |
+| Evening win mentioned | Call it back: "You crushed [thing] yesterday!" |
+| Multiple bad sleep nights | Suggest earlier lights-out |
+| No entries yesterday | Gentle reminder to check in |
+
+#### Schedule-Aware Task Management
+
+When the user asks to add something to their routine via Discord, the agent follows a structured workflow:
+
+1. **Review current schedule** — fetch today's tasks from project 2
+2. **Find gaps** — identify available time slots between existing tasks
+3. **Suggest optimal placement** — based on task type (habit, hobby, errand, appointment)
+4. **Confirm** — present the suggestion with context before creating
+5. **Notify** — post a confirmation embed after creation
+
+Protected slots that cannot be overwritten: hydration reminders, meals, eye breaks, sleep prep (9 PM+). The agent respects day-of-week patterns (strength vs cardio, piano vs guitar).
 
 ### Discord Concepts (quick primer)
 
@@ -809,8 +904,8 @@ Homelab-specific skills live in `skills/` at the repo root and are mounted into 
 | `gitops` | ArgoCD App of Apps pattern, sync management, mandatory git workflow, agent footprint conventions |
 | `incident-response` | Incident triage, rollback procedures, pre-merge validation, post-incident documentation |
 | `secret-management` | Infisical → ESO → K8s pipeline operations |
-| `vikunja` | Vikunja task management API — create, query, update, complete tasks; Discord notifications |
-| `daily-briefing` | AI-powered morning briefing — weather, tasks, cluster health, contextual lifestyle advice |
+| `vikunja` | Vikunja task management API — CRUD tasks, Discord notifications, daily routine (project 2), journal (project 3) with check-ins/reflections, schedule-aware task management |
+| `daily-briefing` | AI morning briefing — weather, tasks, journal-driven advice, owner health profile, weekly schedule with nutrition targets |
 | `weather` | Real-time weather via Open-Meteo and wttr.in (no API key required) |
 | `common/Documentation` | Standardized documentation generation |
 

--- a/k8s/apps/vikunja/README.md
+++ b/k8s/apps/vikunja/README.md
@@ -207,18 +207,39 @@ Note: Changing the PostgreSQL `POSTGRES_PASSWORD` requires a database password u
 
 ## OpenClaw & Discord Integration
 
-Vikunja integrates with OpenClaw and Discord for AI-powered task management and notifications. The integration has three components:
+Vikunja integrates with OpenClaw and Discord for AI-powered task management, a personalized daily routine, and a journal feedback loop. The integration has four components:
 
 1. **OpenClaw → Vikunja** — the `homelab-admin` agent can create, query, update, and complete tasks via the Vikunja REST API
-2. **Discord → Vikunja** — users send natural language commands in Discord (e.g., "add a todo: deploy monitoring"), and OpenClaw translates them into Vikunja API calls
-3. **Vikunja → Discord** — task change notifications are sent to a Discord channel via webhook
+2. **Discord → Vikunja** — users send natural language commands in Discord (e.g., "add meditation to my routine"), and OpenClaw translates them into Vikunja API calls
+3. **Vikunja → Discord** — daily briefings, task notifications, and schedule confirmations are sent to Discord via webhook
+4. **Journal → Briefing** — morning check-ins and evening reflections stored in Vikunja feed back into the next day's AI-generated briefing
+
+### Vikunja Projects
+
+| Project | ID | Purpose | Task count |
+|---|---|---|---|
+| Inbox | 1 | Default project for ad-hoc tasks | Varies |
+| Daily Routine | 2 | 23 recurring tasks — health-focused daily schedule | 23 |
+| Journal | 3 | Morning check-ins + evening reflections (permanent records) | Grows daily |
+
+**Daily Routine (project 2)** contains tasks organized in time blocks: morning (5:30–7:30 AM), work health breaks (8 AM–5 PM), fitness (5:30–6:30 PM), creative (7:30–8:30 PM), and wind-down (8:30–9:30 PM). Tasks include nutrition targets, exercise plans (strength Mon/Wed/Fri, cardio Tue/Thu), creative practice (piano/guitar rotation), and sleep hygiene protocols. All tasks repeat daily via `repeat_after: 86400`.
+
+**Journal (project 3)** stores two entry types:
+
+| Entry type | Time | Label (ID) | Content |
+|---|---|---|---|
+| Morning check-in | 5:35 AM | `morning-checkin` (9) | Sleep quality, energy, headache, mood |
+| Evening reflection | 8:50 PM | `evening-reflection` (10) | 3 interesting things from the day |
+
+Entries are created as tasks with `done: true` (they're records, not to-dos). The daily briefing cron reads yesterday's entries to personalize advice — poor sleep triggers lighter workout suggestions, reported headaches increase hydration reminders, and evening wins get called back the next morning.
 
 ### Prerequisites
 
 | Infisical Secret | Description |
 |---|---|
 | `VIKUNJA_API_TOKEN` | Vikunja API token (created in the Vikunja UI) |
-| `DISCORD_WEBHOOK_VIKUNJA` | Discord webhook URL for task notifications |
+| `DISCORD_WEBHOOK_VIKUNJA` | Discord webhook URL for task notifications and daily briefings |
+| `DISCORD_WEBHOOK_ALERTS` | Discord webhook URL for cluster alerts (used by incident-response skill) |
 
 ### Creating a Vikunja API Token
 
@@ -248,75 +269,136 @@ kubectl rollout restart deployment/openclaw -n openclaw
 
 ### Usage via Discord
 
-Once active, message the OpenClaw bot in Discord:
+Once active, message the OpenClaw bot in the `#daily-briefing` channel (no `@` mention needed):
 
-- `@OpenClaw add a todo: review pull request #99`
-- `@OpenClaw what tasks are due today?`
-- `@OpenClaw complete task 42`
-- `@OpenClaw show my overdue tasks`
+**Task management:**
 
-The `vikunja` skill (assigned to `homelab-admin`) handles the API calls and responds with formatted results.
+- "add a todo: review pull request #99"
+- "what tasks are due today?"
+- "complete task 42"
+- "show my overdue tasks"
+
+**Schedule management (interactive — agent reviews schedule, suggests placement, confirms):**
+
+- "show my schedule" — displays today's routine in time order
+- "add 15 min meditation after singing" — agent finds a gap, suggests 8:15 PM, confirms
+- "move guitar to Saturday" — agent identifies conflicts, offers alternatives
+- "skip workout today" — marks done without breaking recurrence
+- "I have a dentist appointment Thursday 2 PM" — creates a one-time task
+- "what can I fit in after work?" — shows available gaps
+
+**Journal:**
+
+- "slept about 6 hours, slight headache" — agent saves morning check-in to Journal
+- "3 things: fixed DNS, tried new recipe, learned a guitar riff" — agent saves evening reflection
+- "how was my sleep this week?" — agent queries journal entries and summarizes trends
+
+The `vikunja` and `daily-briefing` skills (assigned to `homelab-admin`) handle the API calls and respond with formatted results.
 
 ### Integration Architecture
 
 ```mermaid
 flowchart TD
-    subgraph discord ["Discord"]
+    subgraph discord ["Discord (#daily-briefing)"]
         User["Discord User"]
-        Webhook["Discord Webhook\n(notifications channel)"]
+        Webhook["Discord Webhook\n(briefings + notifications)"]
     end
 
     subgraph openclawNs ["openclaw namespace"]
         OC["OpenClaw Pod\nhomelab-admin agent"]
-        VikSkill["vikunja skill\n(SKILL.md)"]
+        VikSkill["vikunja skill"]
+        BriefSkill["daily-briefing skill"]
+        Cron["Cron Job\n6:30 AM ICT daily"]
         OCSecret["openclaw-secret\nVIKUNJA_API_TOKEN\nDISCORD_WEBHOOK_VIKUNJA"]
-        OC --> VikSkill
+        OC --> VikSkill & BriefSkill
+        Cron -->|"triggers"| OC
         OCSecret -->|"env vars"| OC
     end
 
     subgraph vikunjaNs ["vikunja namespace"]
         VikSvc["Vikunja Service\nClusterIP port 80"]
-        VikPod["Vikunja Pod\ncontainerPort 3456"]
-        VikPG["PostgreSQL\ntask data"]
+        VikPod["Vikunja Pod"]
+        VikPG["PostgreSQL"]
+        Proj2["Project 2\nDaily Routine\n(23 recurring tasks)"]
+        Proj3["Project 3\nJournal\n(check-ins + reflections)"]
         VikSvc -->|"targetPort 3456"| VikPod
         VikPod --> VikPG
+        VikPG --- Proj2 & Proj3
     end
 
     subgraph infisicalNs ["Infisical + ESO"]
         Infisical["Infisical\nhomelab / prod"]
         ESO["External Secrets Operator"]
         Infisical --> ESO
-        ESO -->|"sync openclaw-secret"| OCSecret
+        ESO -->|"sync"| OCSecret
     end
 
-    User -->|"@OpenClaw add a todo..."| OC
-    OC -->|"REST API\nport 80"| VikSvc
+    User -->|"chat: schedule, journal,\ntask commands"| OC
+    OC -->|"REST API"| VikSvc
     OC -->|"Webhook POST\nembeds"| Webhook
     OC -->|"response"| User
 ```
 
-### Data Flow: Discord Command to Task Creation
+### Data Flow: Interactive Schedule Management
 
 ```mermaid
 sequenceDiagram
     participant User as Discord User
     participant OC as OpenClaw<br/>(homelab-admin)
-    participant Vik as Vikunja API<br/>(port 80 -> 3456)
+    participant Vik as Vikunja API<br/>(port 80 → 3456)
     participant DB as PostgreSQL
     participant DW as Discord Webhook
 
-    User->>OC: @OpenClaw add a todo: deploy monitoring
+    User->>OC: "add meditation to my routine"
     OC->>OC: Parse intent via vikunja skill
-    OC->>Vik: GET /api/v1/projects<br/>(list projects, cache default)
-    Vik->>DB: Query projects
-    DB-->>Vik: Project list
-    Vik-->>OC: [{id: 1, title: "Homelab"}]
-    OC->>Vik: PUT /api/v1/projects/1/tasks<br/>{title: "deploy monitoring"}
-    Vik->>DB: INSERT task
+    OC->>Vik: GET /projects/2/tasks?sort_by=due_date<br/>(fetch today's schedule)
+    Vik->>DB: Query project 2 tasks
+    DB-->>Vik: 23 tasks with times
+    Vik-->>OC: Schedule data
+    OC->>OC: Find gap: 8:15–8:30 PM<br/>(between singing and reading)
+    OC-->>User: "I can slot meditation at 8:15 PM.<br/>Want me to add it?"
+    User->>OC: "yes"
+    OC->>Vik: PUT /projects/2/tasks<br/>{title: "Meditation", due: "8:15 PM",<br/>repeat_after: 86400}
+    Vik->>DB: INSERT recurring task
     DB-->>Vik: Task created
-    Vik-->>OC: {id: 42, title: "deploy monitoring"}
-    OC->>DW: POST webhook<br/>{embeds: [{title: "Task Created", ...}]}
-    OC-->>User: Created task #42: deploy monitoring
+    Vik-->>OC: {id: 25, title: "Meditation"}
+    OC->>DW: POST webhook (schedule updated embed)
+    OC-->>User: "Added! Meditation at 8:15 PM daily."
+```
+
+### Data Flow: Journal Feedback Loop
+
+```mermaid
+sequenceDiagram
+    participant User as Discord User
+    participant OC as OpenClaw<br/>(homelab-admin)
+    participant Vik as Vikunja API
+    participant DB as PostgreSQL
+    participant DW as Discord Webhook
+    participant Cron as Cron (6:30 AM)
+
+    Note over User,Cron: Morning Check-in (5:35 AM)
+    User->>OC: "Slept 5 hrs, headache, energy 3/10"
+    OC->>OC: Extract: sleep=5, headache=yes, energy=3
+    OC->>Vik: PUT /projects/3/tasks<br/>{title: "Morning Check-in — Feb 26",<br/>description: structured data, done: true}
+    Vik->>DB: INSERT journal entry
+    OC->>Vik: PUT /tasks/{id}/labels<br/>{label_id: 9 (morning-checkin)}
+    OC-->>User: "Noted. Rough night — lighter workout today,<br/>extra water, take eye breaks every 45 min."
+
+    Note over User,Cron: Evening Reflection (8:50 PM)
+    User->>OC: "1. Fixed DNS 2. New recipe 3. Guitar riff"
+    OC->>Vik: PUT /projects/3/tasks<br/>{title: "Evening Reflection — Feb 26",<br/>description: 3 things, done: true}
+    Vik->>DB: INSERT journal entry
+    OC->>Vik: PUT /tasks/{id}/labels<br/>{label_id: 10 (evening-reflection)}
+    OC-->>User: "Great day! Saved to your journal."
+
+    Note over User,Cron: Next Morning Briefing (6:30 AM)
+    Cron->>OC: Trigger daily-briefing
+    OC->>Vik: GET /projects/3/tasks (yesterday's journal)
+    Vik->>DB: Query journal entries
+    DB-->>Vik: Check-in + reflection
+    OC->>OC: Compose personalized briefing<br/>+ reference yesterday's wins
+    OC->>DW: POST webhook (rich embed briefing)
 ```
 
 ### Secret Flow
@@ -326,6 +408,7 @@ flowchart LR
     subgraph infisical ["Infisical (homelab / prod)"]
         VikToken["VIKUNJA_API_TOKEN"]
         DiscordWH["DISCORD_WEBHOOK_VIKUNJA"]
+        DiscordAlerts["DISCORD_WEBHOOK_ALERTS"]
     end
 
     subgraph eso ["External Secrets Operator"]
@@ -334,16 +417,17 @@ flowchart LR
 
     subgraph k8s ["openclaw namespace"]
         Secret["K8s Secret\nopenclaw-secret"]
-        Pod["OpenClaw Pod\nenv: VIKUNJA_API_TOKEN\nenv: DISCORD_WEBHOOK_VIKUNJA"]
+        Pod["OpenClaw Pod\nenv: VIKUNJA_API_TOKEN\nenv: DISCORD_WEBHOOK_VIKUNJA\nenv: DISCORD_WEBHOOK_ALERTS"]
     end
 
     VikToken --> ES
     DiscordWH --> ES
+    DiscordAlerts --> ES
     ES -->|"creates/updates"| Secret
     Secret -->|"secretKeyRef"| Pod
 ```
 
-Both `VIKUNJA_API_TOKEN` and `DISCORD_WEBHOOK_VIKUNJA` are stored in Infisical, synced by ESO into the existing `openclaw-secret`, and injected as environment variables into the OpenClaw pod. No new ExternalSecret or K8s Secret is needed — the integration piggybacks on the existing OpenClaw secret pipeline.
+All three secrets are stored in Infisical, synced by ESO into the existing `openclaw-secret`, and injected as environment variables into the OpenClaw pod. No new ExternalSecret or K8s Secret is needed — the integration piggybacks on the existing OpenClaw secret pipeline.
 
 ### Network Policies
 


### PR DESCRIPTION
## Summary

Comprehensive documentation update covering all features implemented in PRs #107, #108, and #109 — the personalized daily routine, interactive schedule management, and journal feedback loop.

### OpenClaw README (`k8s/apps/openclaw/README.md`)
- Updated `#daily-briefing` channel table to describe interactive capabilities (schedule queries, journal check-ins, task management, lookback)
- Added full **interaction reference table** with examples for morning check-in, evening reflection, schedule management, and journal lookback
- Added **Daily Routine & Journal System** section:
  - Vikunja projects table (Inbox, Daily Routine, Journal)
  - Routine time blocks (morning, work, fitness, creative, wind-down, weekend)
  - Journal feedback loop mermaid diagram
  - Journal-driven personalization table (sleep → workout advice, headache → hydration, etc.)
  - Schedule-aware task management workflow (review → find gaps → suggest → confirm → notify)
- Updated **Automated Notifications** table for journal-aware briefing
- Updated **skills table** descriptions for `vikunja` and `daily-briefing`

### Vikunja README (`k8s/apps/vikunja/README.md`)
- Rewritten integration overview: 4 components (OpenClaw→Vikunja, Discord→Vikunja, Vikunja→Discord, Journal→Briefing)
- Added **Vikunja Projects** table with project IDs, purposes, and task counts
- Added **Daily Routine** and **Journal** project descriptions with entry types, labels, and data model
- Updated **Prerequisites** to include `DISCORD_WEBHOOK_ALERTS`
- Expanded **Usage via Discord** with task management, schedule management, and journal command examples
- Replaced architecture diagram to show cron, project 2/3, and journal flow
- Replaced data flow diagram with two new sequence diagrams:
  - Interactive Schedule Management (add task → review → suggest gap → confirm → create)
  - Journal Feedback Loop (morning check-in → save → evening reflection → save → next-day briefing)
- Updated **Secret Flow** diagram to include `DISCORD_WEBHOOK_ALERTS`

### AI Agents (`docs/operations/ai-agents.md`)
- Updated `homelab-admin` skill assignment to include `daily-briefing` and `weather`
- Added `daily-briefing` and `weather` skill descriptions to the skills table

### Doc Manifest (`.doc-manifest.yml`)
- Added `skills/daily-briefing/`, `skills/vikunja/`, `skills/incident-response/` to OpenClaw README sources
- Added `skills/vikunja/` to Vikunja README sources

## Test plan

- [ ] Verify MkDocs renders all mermaid diagrams correctly
- [ ] Verify no broken internal links in the documentation
- [ ] Confirm doc-freshness check passes for all updated files


Made with [Cursor](https://cursor.com)