### PR TITLE
scale(mainitoring): set all monitoring pods to 0 until issue resolved

### DIFF
--- a/k8s/apps/argocd/applications/monitoring-app.yaml
+++ b/k8s/apps/argocd/applications/monitoring-app.yaml
@@ -59,6 +59,7 @@ spec:
               mountPath: /etc/secrets
               readOnly: true
           defaultDashboardsEnabled: true
+          replicaCount: 0
           sidecar:
             dashboards:
               enabled: true
@@ -91,6 +92,7 @@ spec:
                   resources:
                     requests:
                       storage: 10Gi
+            replicas: 0
 
         # Alertmanager
         alertmanager:
@@ -114,14 +116,16 @@ spec:
                   resources:
                     requests:
                       storage: 2Gi
+            replicas: 0
 
         # Node exporter
         nodeExporter:
-          enabled: true
+          enabled: false
 
         # kube-state-metrics
         kubeStateMetrics:
           enabled: true
+          replicaCount: 0
 
         # Disable components that don't apply to OrbStack single-node
         kubeProxy:
@@ -132,6 +136,10 @@ spec:
           enabled: false
         kubeControllerManager:
           enabled: false
+
+        # Scale down monitoring operator
+        prometheusOperator:
+          replicaCount: 0
 
   destination:
     server: https://kubernetes.default.svc

--- a/k8s/apps/argocd/applications/trivy-operator-app.yaml
+++ b/k8s/apps/argocd/applications/trivy-operator-app.yaml
@@ -20,14 +20,13 @@ spec:
       valuesObject:
         excludeNamespaces: "openclaw"
         operator:
-          # Disable on-change vulnerability scanning; rely on scheduled VulnerabilityScanner CR
           vulnerabilityScannerEnabled: false
           scanJobsConcurrentLimit: 3
           scanJobTTL: "30m"
           scanJobsRetryDelay: "2m"
           scannerReportTTL: "72h"
           builtInTrivyServer: true
-        # Schedule for config audit (compliance) scans: daily at midnight
+          replicaCount: 0
         compliance:
           cron: "0 0 * * *"
         trivy:
@@ -48,6 +47,7 @@ spec:
               limits:
                 cpu: 500m
                 memory: 512Mi
+            replicaCount: 0
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
- Set grafana replicaCount to 0
- Set prometheus replicas to 0
- Set alertmanager replicas to 0
- Set kube-state-metrics replicaCount to 0
- Set prometheus-operator replicaCount to 0
- Disable nodeExporter
- Scale trivy-operator and trivy server to 0

This is a temporary measure to stop monitoring resource usage while we investigate the underlying issue.