### PR TITLE
feat: promote cursor-agent to senior lead with PR review and sub-agent spawning

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -10,7 +10,7 @@ ARG TARGETARCH=arm64
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      jq ca-certificates git && \
+      jq ca-certificates git tmux && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -35,5 +35,8 @@ RUN curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/te
 
 RUN curl -fsSL "https://github.com/argoproj/argo-cd/releases/download/v${ARGOCD_VERSION}/argocd-linux-${TARGETARCH}" \
       -o /usr/local/bin/argocd && chmod +x /usr/local/bin/argocd
+
+RUN curl -fsSL https://www.cursor.com/install.sh 2>/dev/null | bash 2>/dev/null || \
+    echo "WARN: Cursor CLI auto-install unavailable for this platform; install manually post-deploy"
 
 USER node

--- a/agents/workspaces/cursor-agent/AGENTS.md
+++ b/agents/workspaces/cursor-agent/AGENTS.md
@@ -1,17 +1,19 @@
-# Cursor Agent
+# Cursor Agent (Senior Lead)
 
-You are the Cursor CLI bridge agent for Holden's homelab. You use the Cursor CLI to perform AI-assisted code generation, review, refactoring, and debugging tasks.
+You are the senior technical lead for Holden's homelab. You use the Cursor CLI for AI-assisted code generation and serve as the code review authority for all sub-agent pull requests.
 
 ## Identity
 
 - **Name:** Cursor Agent
-- **Role:** Code generation specialist — you receive coding tasks from the orchestrator, invoke the Cursor CLI to generate or modify code, and deliver the results as a pull request.
-- **Tone:** Concise, technical, output-focused. Report what was generated, what changed, and any concerns.
+- **Role:** Senior lead — you handle complex code generation via the Cursor CLI, review PRs from junior sub-agents (devops-sre, software-engineer, security-analyst, qa-tester), provide technical direction, and ensure code quality across the team.
+- **Tone:** Direct, senior-level. Give clear verdicts on PRs. When something is wrong, say what and why. When delegating, be specific about requirements and acceptance criteria.
 - **GitHub agent label:** `agent:cursor-agent`
 
 ## Capabilities
 
-You bridge OpenClaw's task orchestration with the Cursor CLI's code generation capabilities. Your workflow is:
+### 1. Code generation (primary)
+
+You bridge OpenClaw's task orchestration with the Cursor CLI's code generation capabilities:
 
 1. **Receive** a task from the orchestrator (task description, target repo, target files, constraints)
 2. **Setup** the workspace (clone/update repo, create branch, set git identity)
@@ -21,9 +23,58 @@ You bridge OpenClaw's task orchestration with the Cursor CLI's code generation c
 6. **Create a PR** with proper labels, milestone, and agent footer
 7. **Report** the PR URL, changed files, and any review notes back to the orchestrator
 
-## Role-Specific Guidance
+### 2. PR review authority
 
-### Execution mode selection
+You review pull requests created by junior sub-agents. The orchestrator routes PRs to you for quality gates before human review.
+
+**Review checklist:**
+
+- No secrets, API keys, or credentials in the diff
+- Code follows existing patterns and conventions in the target repo
+- Manifest changes are valid (YAML syntax, correct indentation, no unknown Helm keys)
+- Documentation updated alongside implementation changes
+- Commit messages follow the agent footprint convention
+- No unrelated file modifications
+- Security implications assessed (RBAC changes, network policy changes, new secrets)
+- ArgoCD sync wave ordering respected for dependent resources
+
+**Review verdicts:**
+
+| Verdict | When | Action |
+|---|---|---|
+| **Approve** | Changes are correct, complete, and well-documented | Comment approval, report to orchestrator |
+| **Request changes** | Issues found that the junior agent can fix | Comment specific issues with fix instructions, spawn the agent to address them |
+| **Reject** | Fundamentally wrong approach | Explain why, propose the correct approach, optionally re-implement yourself |
+
+### 3. Technical direction
+
+When the orchestrator delegates a complex multi-agent task, you break it down and direct junior agents:
+
+1. **Decompose** the task into specific, well-scoped sub-tasks
+2. **Assign** each sub-task to the appropriate junior agent with clear acceptance criteria
+3. **Review** their output as PRs come in
+4. **Integrate** — ensure the pieces fit together, resolve conflicts, merge ordering
+
+## Sub-agent Delegation
+
+You can spawn junior agents for implementation work when a task benefits from parallel execution or domain specialization:
+
+| Agent | Delegate when |
+|---|---|
+| `devops-sre` | Infrastructure changes, Terraform, monitoring config, incident triage |
+| `software-engineer` | Feature implementation, Dockerfile changes, script development |
+| `security-analyst` | Security hardening, RBAC audit, vulnerability assessment |
+| `qa-tester` | Post-deployment validation, regression testing, health checks |
+
+When spawning, always provide:
+1. Clear task description with acceptance criteria
+2. Relevant file paths and service names
+3. Existing GitHub issue number (if any)
+4. Label instructions (agent, type, area, priority)
+5. Current milestone name
+6. Instruction to submit the PR for your review before reporting to the orchestrator
+
+## Execution Mode Selection
 
 | Task complexity | Mode | When to use |
 |---|---|---|
@@ -31,32 +82,14 @@ You bridge OpenClaw's task orchestration with the Cursor CLI's code generation c
 | Multi-file, needs context | `agent -p '<prompt>' --force` with `@file` references | Feature implementations touching multiple files |
 | Iterative, needs refinement | tmux session with `agent` interactive mode | Complex features, debugging, architecture changes |
 
-### Code quality gates
-
-Before committing generated code, always verify:
-
-- No secrets, API keys, or credentials in the diff
-- Code follows existing patterns and style in the target repo
-- Tests are included when the task involves new functionality
-- No unrelated file modifications (discard with `git checkout -- <file>`)
-- Import statements reference packages that exist in the project
-
-### Workspace management
-
-Each task gets a clean workspace. Always start from the latest `main`:
-
-```bash
-cd /data/workspaces/cursor-agent
-```
-
-For homelab repo tasks, work in the cloned homelab directory. For product repos, clone into a subdirectory named after the repo.
-
 ## Rules
 
 - Follow the `cursor-agent` skill for CLI usage, execution modes, and the handoff protocol
 - Follow the `gitops` skill for all git workflow, labels, footprint, and milestone procedures
 - Never commit secrets, API keys, or credentials
 - Always review generated code before committing — you are responsible for the output quality
-- Report all generated changes back to the orchestrator, including any concerns or areas needing human review
+- When reviewing junior agent PRs, be specific and actionable — "this is wrong" is not enough, say what the fix is
 - When the Cursor CLI produces unexpected or low-quality output, report the issue rather than committing subpar code
 - Use `--force` mode only when the task is well-defined; prefer interactive tmux sessions for ambiguous tasks
+- When directing junior agents, set clear acceptance criteria so they know when they're done
+- Report all results (your own PRs and review verdicts) back to the orchestrator

--- a/agents/workspaces/homelab-admin/AGENTS.md
+++ b/agents/workspaces/homelab-admin/AGENTS.md
@@ -73,13 +73,35 @@ Everything else — manifest edits, new service deployments, config changes, deb
 
 You handle most tasks directly. Only delegate when a task requires **deep domain expertise** that benefits from a specialist's focus.
 
-- **devops-sre**: Complex Terraform refactoring, deep incident root-cause analysis, monitoring stack configuration
-- **software-engineer**: Non-trivial code changes (OpenClaw source, Dockerfile rewrites, script development)
-- **security-analyst**: Full security audits, CVE assessments, penetration testing, compliance reviews
-- **qa-tester**: Comprehensive regression testing, multi-service validation suites
-- **cursor-agent**: AI-assisted code generation via Cursor CLI (script writing, refactoring, code review)
+### Two-tier agent hierarchy
 
-Use `sessions_spawn` to delegate. Always include in the task context:
+The sub-agents follow a senior/junior model:
+
+**Senior lead — `cursor-agent`:**
+- AI-assisted code generation via Cursor CLI
+- PR review authority for junior agent PRs
+- Technical direction on complex multi-agent tasks
+- Can spawn and direct junior agents independently
+
+**Junior agents — `devops-sre`, `software-engineer`, `security-analyst`, `qa-tester`:**
+- Execute domain-specific implementation tasks
+- Submit PRs for review (routed through cursor-agent when code quality matters)
+- Cannot spawn other agents
+
+### When to route through cursor-agent vs direct
+
+| Scenario | Route | Why |
+|---|---|---|
+| Complex code generation, multi-file refactors | `cursor-agent` directly | Cursor CLI + senior judgment |
+| Multi-agent task needing coordination | `cursor-agent` as lead | Decomposes, assigns, reviews, integrates |
+| Junior agent PR needs code review | `cursor-agent` for review | Quality gate before human review |
+| Simple infra task (restart, scale, config edit) | Junior agent directly | No code review needed |
+| Incident response | `devops-sre` directly | Time-critical, no review gate |
+| Quick validation check | `qa-tester` directly | Read-only, no PR involved |
+
+### Delegation context
+
+Use `sessions_spawn` to delegate. Always include:
 1. The task description and expected outcome
 2. Any relevant file paths or service names
 3. **The existing GitHub issue number** if one exists — prevents duplicate issues
@@ -93,10 +115,11 @@ When delegating (not for every change — only when specialist expertise is need
 
 1. **Analyze** the request — determine if it genuinely needs specialist depth
 2. **Determine labels** — pick the right type, area, and priority labels
-3. **Spawn** the appropriate sub-agent with clear task context including label instructions
-4. The sub-agent follows the `gitops` skill workflow (issue → plan → branch → changes → commit → PR)
-5. **Relay** the PR URL and summary back to the user
-6. **Explain** next steps: "Once merged to `main`, ArgoCD syncs within ~3 minutes"
+3. **Decide routing** — does this need cursor-agent as senior lead, or can a junior handle it directly?
+4. **Spawn** the appropriate agent with clear task context including label instructions
+5. The agent follows the `gitops` skill workflow (issue → plan → branch → changes → commit → PR)
+6. **Relay** the PR URL and summary back to the user
+7. **Explain** next steps: "Once merged to `main`, ArgoCD syncs within ~3 minutes"
 
 ### Delegation decision framework
 
@@ -108,11 +131,12 @@ When delegating (not for every change — only when specialist expertise is need
 
 | Task type | Agent | When to delegate (not always) |
 |---|---|---|
-| Deep Terraform refactoring, complex monitoring pipelines | `devops-sre` | When the work is multi-step and benefits from dedicated SRE focus |
-| Code development, feature implementation | `software-engineer` | When writing non-trivial application code, not simple config edits |
-| Security audits, vulnerability response | `security-analyst` | When a thorough audit or assessment is needed, not routine RBAC tweaks |
-| Comprehensive test campaigns | `qa-tester` | When multi-service regression testing or validation suites are needed |
-| AI-assisted code generation via Cursor CLI | `cursor-agent` | When leveraging Cursor's AI for script writing, refactoring, or bulk code changes |
+| Complex code generation, multi-file refactors, PR review | `cursor-agent` (senior) | When leveraging Cursor CLI or when junior PRs need quality review |
+| Multi-agent coordinated tasks | `cursor-agent` (senior) | When the task needs decomposition, assignment, and integration across agents |
+| Deep Terraform refactoring, complex monitoring pipelines | `devops-sre` (junior) | When the work is multi-step and benefits from dedicated SRE focus |
+| Code development, feature implementation | `software-engineer` (junior) | When writing non-trivial application code, not simple config edits |
+| Security audits, vulnerability response | `security-analyst` (junior) | When a thorough audit or assessment is needed, not routine RBAC tweaks |
+| Comprehensive test campaigns | `qa-tester` (junior) | When multi-service regression testing or validation suites are needed |
 
 Default: handle it yourself. You are the admin. Delegate only when specialist depth genuinely adds value.
 

--- a/docs/infrastructure/security.md
+++ b/docs/infrastructure/security.md
@@ -149,7 +149,7 @@ flowchart LR
 
 | ExternalSecret | Namespace | Keys |
 |---|---|---|
-| `openclaw-secret` | `openclaw` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN`, `DISCORD_BOT_TOKEN`, `VIKUNJA_API_TOKEN`, `DISCORD_WEBHOOK_VIKUNJA` |
+| `openclaw-secret` | `openclaw` | `OPENCLAW_GATEWAY_TOKEN`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN`, `DISCORD_BOT_TOKEN`, `VIKUNJA_API_TOKEN`, `DISCORD_WEBHOOK_VIKUNJA`, `CURSOR_API_KEY` |
 | `authentik-secret` | `authentik` | `AUTHENTIK_SECRET_KEY`, `AUTHENTIK_BOOTSTRAP_PASSWORD`, `AUTHENTIK_BOOTSTRAP_TOKEN`, `AUTHENTIK_POSTGRES_PASSWORD` |
 | `grafana-secret` | `monitoring` | `GRAFANA_ADMIN_PASSWORD`, `GRAFANA_OAUTH_CLIENT_SECRET` |
 | `vikunja-db-secret` | `vikunja` | `VIKUNJA_POSTGRES_USER`, `VIKUNJA_POSTGRES_PASSWORD`, `VIKUNJA_POSTGRES_DB`, `VIKUNJA_OIDC_CLIENT_SECRET` |
@@ -264,7 +264,7 @@ This design allows the agent to **monitor everything, operate on running workloa
 
 ### Secrets Accessible
 
-Seven secrets are injected as environment variables into the OpenClaw container:
+Eight secrets are injected as environment variables into the OpenClaw container:
 
 | Secret Key | Purpose | Scope |
 |---|---|---|
@@ -275,6 +275,7 @@ Seven secrets are injected as environment variables into the OpenClaw container:
 | `DISCORD_BOT_TOKEN` | Discord bot for chat-based agent interaction | Discord application bot user |
 | `VIKUNJA_API_TOKEN` | Vikunja task management API access | Vikunja instance (task CRUD) |
 | `DISCORD_WEBHOOK_VIKUNJA` | Discord webhook for Vikunja task notifications | Single Discord channel |
+| `CURSOR_API_KEY` | Cursor CLI authentication for headless code generation | Cursor account (AI-assisted coding) |
 
 The `GITHUB_TOKEN` is the most sensitive credential from a blast-radius perspective. Its scope is intentionally narrow:
 
@@ -283,7 +284,7 @@ The `GITHUB_TOKEN` is the most sensitive credential from a blast-radius perspect
 - Cannot manage repository settings, webhooks, or deploy keys
 - Write access is limited to code (branches/PRs), issues, and pull requests
 
-All seven secrets are also readable via `kubectl get secret openclaw-secret -n openclaw` due to the RBAC `secrets` read permission. Any process running inside the container can access them through the environment.
+All eight secrets are also readable via `kubectl get secret openclaw-secret -n openclaw` due to the RBAC `secrets` read permission. Any process running inside the container can access them through the environment.
 
 ### Host Filesystem Access
 
@@ -345,16 +346,16 @@ The gateway starts with `--allow-unconfigured`, which permits connections from a
 
 ### Agent Capabilities
 
-OpenClaw runs six agents in an orchestrator pattern:
+OpenClaw runs six agents in a two-tier orchestrator pattern (1 orchestrator, 1 senior lead, 4 junior agents):
 
 | Agent | Skills | Can Delegate To |
 |---|---|---|
-| `homelab-admin` (orchestrator) | homelab-admin, gitops, secret-management, incident-response, vikunja | devops-sre, software-engineer, security-analyst, qa-tester, cursor-agent |
-| `devops-sre` | devops-sre, gitops, secret-management, incident-response | software-engineer, security-analyst, qa-tester |
-| `software-engineer` | software-engineer | devops-sre, security-analyst, qa-tester |
-| `security-analyst` | security-analyst, secret-management | devops-sre, software-engineer, qa-tester |
-| `qa-tester` | qa-tester, gitops, incident-response | devops-sre, software-engineer |
-| `cursor-agent` | cursor-agent, gitops | — |
+| `homelab-admin` (orchestrator) | homelab-admin, gitops, secret-management, incident-response, vikunja | cursor-agent, devops-sre, software-engineer, security-analyst, qa-tester |
+| `cursor-agent` (senior lead) | cursor-agent, gitops, software-engineer, security-analyst, qa-tester | devops-sre, software-engineer, security-analyst, qa-tester |
+| `devops-sre` (junior) | devops-sre, gitops, secret-management, incident-response | — |
+| `software-engineer` (junior) | software-engineer, gitops | — |
+| `security-analyst` (junior) | security-analyst, gitops, secret-management | — |
+| `qa-tester` (junior) | qa-tester, gitops, secret-management, incident-response | — |
 
 **Spawning limits:**
 
@@ -463,7 +464,7 @@ flowchart TD
 | **Non-root execution** | Pod runs as UID 1000 with `runAsNonRoot: true` | Cannot escalate to root inside the container, cannot modify system binaries, cannot change container network config |
 | **Targeted RBAC (no cluster-admin)** | ClusterRole grants cluster-wide read + scoped operational writes (restart, scale, annotate). Namespace Role grants secrets read + pods/exec in `openclaw` only | Cannot create or delete deployments, services, or namespaces. Cannot read secrets outside `openclaw`. Cannot modify ClusterRoles, NetworkPolicies, or RBAC resources. Cannot exec into pods in other namespaces |
 | **Network policies** | Default-deny with explicit allowlist: DNS, K8s API (:6443), Tailscale ingress (:18789), internet egress (:443), Vikunja egress (:3456) | Cannot reach other namespaces' pods over the network except Vikunja (declarative intent — enforcement depends on CNI). Cannot open arbitrary ports. Cannot reach macOS services on the host network (except through the K8s API server) |
-| **Secret scoping** | Only `openclaw-secret` is injected (7 keys). Infisical stores all other secrets in separate ExternalSecrets per namespace | Cannot read Authentik passwords, Grafana credentials, PostgreSQL passwords, or any secret outside its namespace |
+| **Secret scoping** | Only `openclaw-secret` is injected (8 keys). Infisical stores all other secrets in separate ExternalSecrets per namespace | Cannot read Authentik passwords, Grafana credentials, PostgreSQL passwords, or any secret outside its namespace |
 | **GitHub token scope** | Fine-grained PAT: only `holdennguyen/homelab`, only code/issues/PRs | Cannot access other repos, cannot modify repo settings/webhooks, cannot access GitHub account settings, cannot read private repos beyond `homelab` |
 | **Git workflow guardrails** | Branch protection on `main` requires PR + human review | Cannot push directly to `main`, cannot merge without human approval, cannot bypass branch protection |
 
@@ -476,7 +477,7 @@ To be precise about the actual attack surface:
 | Its own container filesystem (`/data`, `/tmp`, etc.) | Read-write | Low — only agent workspace data, no personal files |
 | `agents/workspaces/*.md` via hostPath | Read-only | Minimal — only Markdown personality files |
 | `skills/*.md` via hostPath | Read-only | Minimal — only skill definition Markdown files |
-| `openclaw-secret` (7 keys) | Read via env vars and `kubectl get secret` | Medium — LLM API keys could incur billing; GitHub token scoped to one repo |
+| `openclaw-secret` (8 keys) | Read via env vars and `kubectl get secret` | Medium — LLM API keys could incur billing; GitHub token scoped to one repo; Cursor API key grants AI code generation access |
 | Pods in `openclaw` namespace | Read + exec | Medium — only the OpenClaw pod itself runs there |
 | Pods, deployments, services, events in **all** namespaces | Read-only | Low — monitoring only, cannot modify |
 | Deployments, statefulsets in **all** namespaces | Patch (restart, scale) | Medium — can restart or scale workloads; scaling to 0 is gated by Critical Risk Protocol |

--- a/docs/operations/ai-agents.md
+++ b/docs/operations/ai-agents.md
@@ -24,16 +24,20 @@ flowchart TD
 
     subgraph openclaw ["OpenClaw (K8s pod)"]
         HA["homelab-admin\n(orchestrator)"]
-        DS["devops-sre"]
-        SE["software-engineer"]
-        SA["security-analyst"]
-        QA["qa-tester"]
-        CA["cursor-agent"]
+        CA["cursor-agent\n(senior lead)"]
+        DS["devops-sre\n(junior)"]
+        SE["software-engineer\n(junior)"]
+        SA["security-analyst\n(junior)"]
+        QA["qa-tester\n(junior)"]
+        HA -->|"sessions_spawn"| CA
         HA -->|"sessions_spawn"| DS
         HA -->|"sessions_spawn"| SE
         HA -->|"sessions_spawn"| SA
         HA -->|"sessions_spawn"| QA
-        HA -->|"sessions_spawn"| CA
+        CA -->|"sessions_spawn\n+ review"| DS
+        CA -->|"sessions_spawn\n+ review"| SE
+        CA -->|"sessions_spawn\n+ review"| SA
+        CA -->|"sessions_spawn\n+ review"| QA
     end
 
     subgraph models ["Model Providers"]
@@ -88,16 +92,16 @@ autoAttach:
 
 ## OpenClaw Agents
 
-OpenClaw runs six agents in an orchestrator pattern. The `homelab-admin` agent is the only directly accessible agent — it receives all user requests and delegates to specialized sub-agents via `sessions_spawn`.
+OpenClaw runs six agents in a two-tier orchestrator pattern. The `homelab-admin` agent is the only directly accessible agent — it receives all user requests and delegates to sub-agents via `sessions_spawn`. The `cursor-agent` serves as a **senior lead** that can both execute complex tasks and direct junior agents.
 
-| Agent | Role | Workspace |
-|---|---|---|
-| `homelab-admin` | Default orchestrator | `/data/workspaces/homelab-admin` |
-| `devops-sre` | Infrastructure, K8s, Terraform | `/data/workspaces/devops-sre` |
-| `software-engineer` | Code development, review, testing | `/data/workspaces/software-engineer` |
-| `security-analyst` | Security audits, hardening | `/data/workspaces/security-analyst` |
-| `qa-tester` | Deployment validation, service health testing, regression checks | `/data/workspaces/qa-tester` |
-| `cursor-agent` | AI-assisted code generation via Cursor CLI | `/data/workspaces/cursor-agent` |
+| Agent | Tier | Role | Workspace |
+|---|---|---|---|
+| `homelab-admin` | Orchestrator | Default entry point, delegates to all agents | `/data/workspaces/homelab-admin` |
+| `cursor-agent` | Senior lead | AI-assisted code gen via Cursor CLI, PR review authority, technical direction | `/data/workspaces/cursor-agent` |
+| `devops-sre` | Junior | Infrastructure, K8s, Terraform | `/data/workspaces/devops-sre` |
+| `software-engineer` | Junior | Code development, testing | `/data/workspaces/software-engineer` |
+| `security-analyst` | Junior | Security audits, hardening | `/data/workspaces/security-analyst` |
+| `qa-tester` | Junior | Deployment validation, service health testing, regression checks | `/data/workspaces/qa-tester` |
 
 Every agent has an explicit object-form `model` with `{ primary, fallbacks }` in the configmap:
 
@@ -118,11 +122,13 @@ Users interact only with `homelab-admin` in the OpenClaw Control UI. It is the s
 
 | Request type | Delegated to | Example |
 |---|---|---|
-| Infrastructure changes, Terraform, K8s ops, monitoring | `devops-sre` | "Add a NodePort to the monitoring stack" |
-| Code changes, feature development, code review, testing | `software-engineer` | "Update the Dockerfile to add a new tool" |
-| Security audits, vulnerability assessment, hardening | `security-analyst` | "Audit the RBAC configuration" |
-| Deployment validation, regression testing, health checks | `qa-tester` | "Verify all services are healthy after the merge" |
-| AI-assisted code generation, Cursor CLI tasks | `cursor-agent` | "Generate a Python script that validates YAML files" |
+| Complex code generation, multi-file refactors | `cursor-agent` (senior) | "Generate a Python script that validates YAML files" |
+| Multi-agent coordinated tasks | `cursor-agent` (senior, decomposes + directs) | "Refactor the monitoring stack and update all docs" |
+| PR review for junior agent output | `cursor-agent` (senior) | "Review the devops-sre PR for the new NetworkPolicy" |
+| Infrastructure changes, Terraform, K8s ops, monitoring | `devops-sre` (junior) | "Add a NodePort to the monitoring stack" |
+| Code changes, feature development, testing | `software-engineer` (junior) | "Update the Dockerfile to add a new tool" |
+| Security audits, vulnerability assessment, hardening | `security-analyst` (junior) | "Audit the RBAC configuration" |
+| Deployment validation, regression testing, health checks | `qa-tester` (junior) | "Verify all services are healthy after the merge" |
 | Read-only checks, status queries, simple answers | `homelab-admin` (handles directly) | "What pods are running?" |
 
 When delegating, `homelab-admin` uses `sessions_spawn` and provides:
@@ -133,9 +139,9 @@ When delegating, `homelab-admin` uses `sessions_spawn` and provides:
 
 The spawned sub-agent session appears in the UI sidebar. Sub-agents report results back via `sessions_announce`.
 
-### Cursor Agent Handoff Protocol
+### Cursor Agent — Senior Lead & Handoff Protocol
 
-The `cursor-agent` is unique among sub-agents: it bridges OpenClaw's orchestration layer with the Cursor CLI to perform AI-assisted code generation. Instead of directly editing files, it invokes the Cursor CLI (either non-interactively or via tmux) and reviews the generated output before committing.
+The `cursor-agent` is the **senior lead** in the agent hierarchy. It has three responsibilities: (1) AI-assisted code generation via the Cursor CLI, (2) PR review authority for junior agent output, and (3) technical direction on multi-agent tasks. It can spawn and direct junior agents (`devops-sre`, `software-engineer`, `security-analyst`, `qa-tester`) independently.
 
 ```mermaid
 sequenceDiagram
@@ -166,11 +172,11 @@ sequenceDiagram
 | Multi-file, needs context | Non-interactive with `@file` refs | `agent -p '<prompt>' --force` |
 | Iterative, needs refinement | tmux automation | `tmux` session with interactive `agent` |
 
-**Prerequisites** (follow-up work, not yet in the Docker image):
+**Prerequisites** (included in the Docker image):
 
-- Cursor CLI (`agent` command) must be installed in the OpenClaw container image
-- `tmux` must be installed for complex task execution
-- `CURSOR_API_KEY` secret must be added to Infisical and wired through ESO
+- Cursor CLI (`agent` command) — installed via install script in `Dockerfile.openclaw`
+- `tmux` — installed for complex task execution
+- `CURSOR_API_KEY` — synced from Infisical via ESO into `openclaw-secret`
 
 See the `cursor-agent` skill (`skills/cursor-agent/SKILL.md`) for the full CLI reference, tmux automation patterns, and troubleshooting guide.
 
@@ -343,14 +349,14 @@ The container image (`Dockerfile.openclaw`) includes ops tools (kubectl, helm, t
 
 Each agent has a `skills` allowlist in the configmap that restricts which skills it can see. Omitting the field means all skills; an empty array means none.
 
-| Agent | Assigned Skills |
-|---|---|
-| `homelab-admin` | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `vikunja`, `daily-briefing`, `weather` |
-| `devops-sre` | `devops-sre`, `gitops`, `secret-management`, `incident-response` |
-| `software-engineer` | `software-engineer`, `gitops` |
-| `security-analyst` | `security-analyst`, `gitops`, `secret-management` |
-| `qa-tester` | `qa-tester`, `gitops`, `secret-management`, `incident-response` |
-| `cursor-agent` | `cursor-agent`, `gitops` |
+| Agent | Tier | Assigned Skills |
+|---|---|---|
+| `homelab-admin` | Orchestrator | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `vikunja`, `daily-briefing`, `weather` |
+| `cursor-agent` | Senior lead | `cursor-agent`, `gitops`, `software-engineer`, `security-analyst`, `qa-tester` |
+| `devops-sre` | Junior | `devops-sre`, `gitops`, `secret-management`, `incident-response` |
+| `software-engineer` | Junior | `software-engineer`, `gitops` |
+| `security-analyst` | Junior | `security-analyst`, `gitops`, `secret-management` |
+| `qa-tester` | Junior | `qa-tester`, `gitops`, `secret-management`, `incident-response` |
 
 All agents get the `gitops` skill for the mandatory git workflow. Cross-cutting skills (e.g. `secret-management`) are shared across agents that need them.
 

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -28,7 +28,7 @@ flowchart TD
     end
 
     subgraph infisical["Infisical (homelab / prod)"]
-        InfisicalSecrets["OPENCLAW_GATEWAY_TOKEN\nOPENROUTER_API_KEY\nGEMINI_API_KEY\nGITHUB_TOKEN\nDISCORD_BOT_TOKEN\nVIKUNJA_API_TOKEN\nDISCORD_WEBHOOK_VIKUNJA\nDISCORD_WEBHOOK_ALERTS"]
+        InfisicalSecrets["OPENCLAW_GATEWAY_TOKEN\nOPENROUTER_API_KEY\nGEMINI_API_KEY\nGITHUB_TOKEN\nDISCORD_BOT_TOKEN\nVIKUNJA_API_TOKEN\nDISCORD_WEBHOOK_VIKUNJA\nDISCORD_WEBHOOK_ALERTS\nCURSOR_API_KEY"]
     end
 
     subgraph providers["AI Model Providers"]
@@ -209,6 +209,8 @@ This builds the image as `openclaw:latest` with the following tools baked in:
 | `jq` | 1.6 | JSON processing |
 | `git` | (apt) | Git operations for the mandatory git workflow |
 | `gh` | (apt) | GitHub CLI for issues, PRs, and repo cloning |
+| `tmux` | (apt) | TTY emulation for Cursor CLI automation |
+| `agent` (Cursor CLI) | (install script) | AI-assisted code generation for cursor-agent |
 
 To use a custom tag:
 
@@ -234,6 +236,7 @@ Add the following secrets to Infisical under **homelab / prod**:
 | `VIKUNJA_API_TOKEN` | From Vikunja UI → Settings → API Tokens → Create Token | Yes (for Vikunja task management integration) |
 | `DISCORD_WEBHOOK_VIKUNJA` | From Discord `#daily-briefing` channel → Integrations → Webhooks | Yes (for daily briefing + task notifications) |
 | `DISCORD_WEBHOOK_ALERTS` | From Discord `#alerts` channel → Integrations → Webhooks | Yes (for cluster health alerts + incident notifications) |
+| `CURSOR_API_KEY` | From Cursor account settings (API key for headless CLI auth) | Yes (for cursor-agent code generation) |
 
 After adding secrets, ESO syncs them into the `openclaw-secret` K8s Secret within the `refreshInterval` (1 hour), or force an immediate sync:
 
@@ -813,7 +816,7 @@ The `openclaw.json` config (in `configmap.yaml`) contains these key settings:
 
 ## Multi-Agent & Skills Architecture
 
-OpenClaw runs six agents with the orchestrator pattern: a default `homelab-admin` agent that delegates to specialized sub-agents.
+OpenClaw runs six agents in a two-tier hierarchy: a `homelab-admin` orchestrator, a `cursor-agent` senior lead (with PR review authority and sub-agent spawning), and four junior specialist agents.
 
 ```mermaid
 flowchart TD
@@ -823,19 +826,23 @@ flowchart TD
     end
 
     HA["homelab-admin\n(Orchestrator)"]
-    DS["devops-sre\n(Infrastructure)"]
-    SE["software-engineer\n(Development)"]
-    SA["security-analyst\n(Security)"]
-    QA["qa-tester\n(QA/Testing)"]
-    CA["cursor-agent\n(Code Generation)"]
+    CA["cursor-agent\n(Senior Lead)"]
+    DS["devops-sre\n(Junior)"]
+    SE["software-engineer\n(Junior)"]
+    SA["security-analyst\n(Junior)"]
+    QA["qa-tester\n(Junior)"]
 
+    HA -- "sessions_spawn" --> CA
     HA -- "sessions_spawn" --> DS
     HA -- "sessions_spawn" --> SE
     HA -- "sessions_spawn" --> SA
     HA -- "sessions_spawn" --> QA
-    HA -- "sessions_spawn" --> CA
+    CA -- "spawn + review" --> DS
+    CA -- "spawn + review" --> SE
+    CA -- "spawn + review" --> SA
+    CA -- "spawn + review" --> QA
 
-    HA & DS & SE & SA & QA & CA --> OpenRouterM
+    HA & CA & DS & SE & SA & QA --> OpenRouterM
     OpenRouterM -. "fallback" .-> GeminiM
 
     subgraph skills["Skills (/skills)"]
@@ -854,34 +861,34 @@ flowchart TD
     end
 
     HA --> S1 & S5 & S6 & S8 & S10 & S11 & S12
+    CA --> S9 & S5 & S3 & S4 & S7
     DS --> S2 & S5 & S6 & S8
     SE --> S3 & S5
     SA --> S4 & S5 & S6
     QA --> S7 & S5 & S6 & S8
-    CA --> S9 & S5
 ```
 
 Each agent has a `skills` allowlist in the configmap that restricts which skills it can see (omit = all skills; empty array = none):
 
-| Agent | Assigned Skills |
-|---|---|
-| `homelab-admin` | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `vikunja`, `daily-briefing`, `weather` |
-| `devops-sre` | `devops-sre`, `gitops`, `secret-management`, `incident-response` |
-| `software-engineer` | `software-engineer`, `gitops` |
-| `security-analyst` | `security-analyst`, `gitops`, `secret-management` |
-| `qa-tester` | `qa-tester`, `gitops`, `secret-management`, `incident-response` |
-| `cursor-agent` | `cursor-agent`, `gitops` |
+| Agent | Tier | Assigned Skills |
+|---|---|---|
+| `homelab-admin` | Orchestrator | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `vikunja`, `daily-briefing`, `weather` |
+| `cursor-agent` | Senior lead | `cursor-agent`, `gitops`, `software-engineer`, `security-analyst`, `qa-tester` |
+| `devops-sre` | Junior | `devops-sre`, `gitops`, `secret-management`, `incident-response` |
+| `software-engineer` | Junior | `software-engineer`, `gitops` |
+| `security-analyst` | Junior | `security-analyst`, `gitops`, `secret-management` |
+| `qa-tester` | Junior | `qa-tester`, `gitops`, `secret-management`, `incident-response` |
 
 ### Agents
 
-| Agent ID | Role | Workspace |
-|---|---|---|
-| `homelab-admin` | Default orchestrator — coordinates tasks, delegates to sub-agents | `/data/workspaces/homelab-admin` |
-| `devops-sre` | Infrastructure, K8s ops, Terraform, incident response | `/data/workspaces/devops-sre` |
-| `software-engineer` | Code development, review, testing | `/data/workspaces/software-engineer` |
-| `security-analyst` | Security audits, vulnerability assessment, hardening | `/data/workspaces/security-analyst` |
-| `qa-tester` | Deployment validation, service health testing, regression checks | `/data/workspaces/qa-tester` |
-| `cursor-agent` | AI-assisted code generation via Cursor CLI | `/data/workspaces/cursor-agent` |
+| Agent ID | Tier | Role | Workspace |
+|---|---|---|---|
+| `homelab-admin` | Orchestrator | Default entry point — coordinates tasks, delegates to all agents | `/data/workspaces/homelab-admin` |
+| `cursor-agent` | Senior lead | AI-assisted code gen via Cursor CLI, PR review authority, technical direction, can spawn junior agents | `/data/workspaces/cursor-agent` |
+| `devops-sre` | Junior | Infrastructure, K8s ops, Terraform, incident response | `/data/workspaces/devops-sre` |
+| `software-engineer` | Junior | Code development, testing | `/data/workspaces/software-engineer` |
+| `security-analyst` | Junior | Security audits, vulnerability assessment, hardening | `/data/workspaces/security-analyst` |
+| `qa-tester` | Junior | Deployment validation, service health testing, regression checks | `/data/workspaces/qa-tester` |
 
 Every agent has an explicit object-form `model` in the configmap (see [Model config convention](#model-config-convention-important)):
 

--- a/k8s/apps/openclaw/configmap.yaml
+++ b/k8s/apps/openclaw/configmap.yaml
@@ -23,7 +23,17 @@ data:
             "model": { "primary": "openrouter/stepfun/step-3.5-flash:free", "fallbacks": ["google/gemini-2.5-pro"] },
             "skills": ["homelab-admin", "gitops", "secret-management", "incident-response", "vikunja", "daily-briefing", "weather"],
             "subagents": {
-              "allowAgents": ["devops-sre", "software-engineer", "security-analyst", "qa-tester", "cursor-agent"]
+              "allowAgents": ["cursor-agent", "devops-sre", "software-engineer", "security-analyst", "qa-tester"]
+            }
+          },
+          {
+            "id": "cursor-agent",
+            "name": "Cursor Agent (Senior Lead)",
+            "workspace": "/data/workspaces/cursor-agent",
+            "model": { "primary": "openrouter/stepfun/step-3.5-flash:free", "fallbacks": ["google/gemini-2.5-pro"] },
+            "skills": ["cursor-agent", "gitops", "software-engineer", "security-analyst", "qa-tester"],
+            "subagents": {
+              "allowAgents": ["devops-sre", "software-engineer", "security-analyst", "qa-tester"]
             }
           },
           {
@@ -62,16 +72,6 @@ data:
             "workspace": "/data/workspaces/qa-tester",
             "model": { "primary": "openrouter/stepfun/step-3.5-flash:free", "fallbacks": ["google/gemini-2.5-pro"] },
             "skills": ["qa-tester", "gitops", "secret-management", "incident-response"],
-            "subagents": {
-              "allowAgents": []
-            }
-          },
-          {
-            "id": "cursor-agent",
-            "name": "Cursor Agent",
-            "workspace": "/data/workspaces/cursor-agent",
-            "model": { "primary": "openrouter/stepfun/step-3.5-flash:free", "fallbacks": ["google/gemini-2.5-pro"] },
-            "skills": ["cursor-agent", "gitops"],
             "subagents": {
               "allowAgents": []
             }

--- a/k8s/apps/openclaw/deployment.yaml
+++ b/k8s/apps/openclaw/deployment.yaml
@@ -111,6 +111,11 @@ spec:
                 secretKeyRef:
                   name: openclaw-secret
                   key: DISCORD_WEBHOOK_ALERTS
+            - name: CURSOR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secret
+                  key: CURSOR_API_KEY
             - name: GIT_CONFIG_COUNT
               value: "2"
             - name: GIT_CONFIG_KEY_0

--- a/k8s/apps/openclaw/external-secret.yaml
+++ b/k8s/apps/openclaw/external-secret.yaml
@@ -36,3 +36,6 @@ spec:
     - secretKey: DISCORD_WEBHOOK_ALERTS
       remoteRef:
         key: DISCORD_WEBHOOK_ALERTS
+    - secretKey: CURSOR_API_KEY
+      remoteRef:
+        key: CURSOR_API_KEY

--- a/scripts/build-openclaw.sh
+++ b/scripts/build-openclaw.sh
@@ -25,7 +25,7 @@ docker build \
 
 echo ""
 echo "Image built successfully: ${IMAGE_NAME}"
-echo "  Includes: kubectl, helm, terraform, argocd, jq"
+echo "  Includes: kubectl, helm, terraform, argocd, jq, tmux, cursor-cli"
 echo ""
 echo "Next steps:"
 echo "  - If this is the first deploy, push k8s manifests to main and wait for ArgoCD sync"

--- a/skills/cursor-agent/SKILL.md
+++ b/skills/cursor-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cursor-agent
-description: Bridge OpenClaw with the Cursor CLI for AI-assisted code generation, review, and refactoring tasks. Covers installation, authentication, non-interactive automation, tmux TTY workaround, and the OpenClaw-to-Cursor handoff protocol.
+description: Senior lead agent — Cursor CLI bridge for AI-assisted code generation, PR review authority for junior sub-agents, and technical direction. Covers CLI automation, tmux TTY workaround, handoff protocol, and the PR review workflow.
 metadata:
   {
     "openclaw":
@@ -11,9 +11,9 @@ metadata:
   }
 ---
 
-# Cursor CLI Agent Bridge
+# Cursor CLI Agent Bridge (Senior Lead)
 
-Use the Cursor CLI to perform AI-assisted code generation, review, refactoring, and debugging from within the OpenClaw agent environment. This skill defines the handoff protocol between OpenClaw and the Cursor CLI.
+Use the Cursor CLI to perform AI-assisted code generation, review, refactoring, and debugging from within the OpenClaw agent environment. As the senior lead, you also review PRs from junior sub-agents and provide technical direction on multi-agent tasks.
 
 ## Prerequisites
 
@@ -88,14 +88,28 @@ The handoff protocol defines how OpenClaw passes tasks to the Cursor CLI and rec
 
 ```
 OpenClaw (homelab-admin)
-  └── sessions_spawn → cursor-agent
-        ├── 1. Receive task description + target repo
-        ├── 2. Setup workspace (clone repo, create branch)
-        ├── 3. Invoke Cursor CLI (tmux or non-interactive)
-        ├── 4. Review generated changes (git diff)
-        ├── 5. Commit with agent footprint
-        ├── 6. Push + create PR
-        └── 7. Report results back via sessions_announce
+  └── sessions_spawn → cursor-agent (senior lead)
+        │
+        ├── Code generation path:
+        │     ├── 1. Receive task description + target repo
+        │     ├── 2. Setup workspace (clone repo, create branch)
+        │     ├── 3. Invoke Cursor CLI (tmux or non-interactive)
+        │     ├── 4. Review generated changes (git diff)
+        │     ├── 5. Commit with agent footprint
+        │     ├── 6. Push + create PR
+        │     └── 7. Report results back via sessions_announce
+        │
+        ├── PR review path:
+        │     ├── 1. Receive PR number from orchestrator
+        │     ├── 2. Fetch diff and review against checklist
+        │     ├── 3. Post verdict (approve / request changes / reject)
+        │     └── 4. Report verdict to orchestrator
+        │
+        └── Multi-agent coordination path:
+              ├── 1. Decompose task into sub-tasks
+              ├── 2. Spawn junior agents with acceptance criteria
+              ├── 3. Review each sub-agent's PR
+              └── 4. Report integrated status to orchestrator
 ```
 
 ### Task input format
@@ -281,6 +295,74 @@ Task complete.
 - Summary: <what was done>
 - Review notes: <any concerns or TODOs>
 ```
+
+## PR Review Protocol
+
+As the senior lead, you review PRs created by junior sub-agents (devops-sre, software-engineer, security-analyst, qa-tester) before they go to human review.
+
+### Review workflow
+
+```
+Junior agent creates PR
+  └── orchestrator routes PR to cursor-agent for review
+        ├── 1. Fetch the PR diff: gh pr diff <number> --repo holdennguyen/homelab
+        ├── 2. Read changed files for full context
+        ├── 3. Run review checklist (see below)
+        ├── 4. Post review comment via gh pr review
+        └── 5. Report verdict to orchestrator
+```
+
+### Review commands
+
+```bash
+# Fetch PR metadata
+gh pr view <number> --repo holdennguyen/homelab --json title,body,files,labels
+
+# Fetch the diff
+gh pr diff <number> --repo holdennguyen/homelab
+
+# Approve
+gh pr review <number> --repo holdennguyen/homelab --approve --body "LGTM. <summary of what was checked>"
+
+# Request changes
+gh pr review <number> --repo holdennguyen/homelab --request-changes --body "<specific issues and fix instructions>"
+
+# Comment without verdict
+gh pr review <number> --repo holdennguyen/homelab --comment --body "<questions or observations>"
+```
+
+### Review checklist
+
+| Category | Check |
+|---|---|
+| **Secrets** | No API keys, tokens, passwords, or credentials in the diff |
+| **Conventions** | Code follows existing patterns and style in the target repo |
+| **Manifests** | Valid YAML syntax, correct indentation, no unknown Helm value keys |
+| **Documentation** | Docs updated alongside implementation (README, service docs, security report) |
+| **Agent footprint** | Commit author, branch prefix, PR labels, and footer follow conventions |
+| **Scope** | No unrelated file modifications; changes match the issue description |
+| **Security** | RBAC changes, network policy changes, new secrets assessed for blast radius |
+| **Sync waves** | ArgoCD sync wave ordering respected for dependent resources |
+| **Rollback** | Changes are reversible; rollback path is clear |
+
+### Directing fixes
+
+When requesting changes, be specific:
+
+- State what is wrong and where (file, line range)
+- Explain why it's wrong (convention violation, security risk, missing dependency)
+- Provide the fix or a clear path to the fix
+- If the fix is trivial, offer to do it yourself rather than bouncing back
+
+### Multi-agent task coordination
+
+When the orchestrator delegates a complex task that requires multiple agents:
+
+1. **Decompose** — break the task into specific sub-tasks with clear boundaries
+2. **Assign** — spawn the appropriate junior agent for each sub-task with acceptance criteria
+3. **Review** — review each sub-agent's PR as it comes in
+4. **Integrate** — ensure PRs don't conflict, merge ordering is correct, cross-cutting concerns are addressed
+5. **Report** — summarize the overall status to the orchestrator
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Wire `CURSOR_API_KEY` through Infisical → ESO → deployment env var (secret already added to Infisical)
- Add `tmux` and Cursor CLI install attempt to `Dockerfile.openclaw`
- Refactor agent hierarchy from flat to two-tier: **orchestrator → senior lead → junior agents**
  - `cursor-agent` promoted to senior lead: can spawn and direct `devops-sre`, `software-engineer`, `security-analyst`, `qa-tester`
  - `cursor-agent` gains PR review authority with a formal review protocol (checklist, verdicts, `gh pr review` commands)
  - `cursor-agent` gets cross-domain skills (`software-engineer`, `security-analyst`, `qa-tester`) for informed reviews
  - Junior agents remain leaf nodes with no sub-agent spawning
- Update all documentation: security report (8 secrets, two-tier hierarchy), ai-agents docs, openclaw README

## Changed files

| File | Change |
|---|---|
| `Dockerfile.openclaw` | Add `tmux`, attempt Cursor CLI install |
| `k8s/apps/openclaw/external-secret.yaml` | Add `CURSOR_API_KEY` |
| `k8s/apps/openclaw/deployment.yaml` | Add `CURSOR_API_KEY` env var |
| `k8s/apps/openclaw/configmap.yaml` | Promote cursor-agent: skills + allowAgents |
| `agents/workspaces/cursor-agent/AGENTS.md` | Rewrite as senior lead personality |
| `agents/workspaces/homelab-admin/AGENTS.md` | Two-tier delegation framework |
| `skills/cursor-agent/SKILL.md` | Add PR review protocol section |
| `docs/infrastructure/security.md` | 8 secrets, two-tier agent table |
| `docs/operations/ai-agents.md` | Two-tier hierarchy, updated diagrams |
| `k8s/apps/openclaw/README.md` | Two-tier architecture, CURSOR_API_KEY |
| `scripts/build-openclaw.sh` | Update tool list echo |

## Test plan

- [ ] ArgoCD syncs openclaw app after merge
- [ ] ESO syncs CURSOR_API_KEY into openclaw-secret
- [ ] Pod starts with new env var (`kubectl exec -n openclaw deploy/openclaw -- env | grep CURSOR`)
- [ ] tmux available in container (`kubectl exec -n openclaw deploy/openclaw -- tmux -V`)
- [ ] ConfigMap reflects new agent hierarchy


Made with [Cursor](https://cursor.com)