### PR TITLE
docs: refresh OpenClaw and AI Agents documentation for current agent set

### DIFF
--- a/docs/operations/ai-agents.md
+++ b/docs/operations/ai-agents.md
@@ -92,7 +92,7 @@ autoAttach:
 
 ## OpenClaw Agents
 
-OpenClaw runs six agents in a two-tier orchestrator pattern. The `homelab-admin` agent is the only directly accessible agent — it receives all user requests and delegates to sub-agents via `sessions_spawn`. The `cursor-agent` serves as a **senior lead** that can both execute complex tasks and direct junior agents.
+OpenClaw runs nine agents in total: six core agents in a two-tier orchestrator pattern, and three specialist agents for domain-specific tasks. The `homelab-admin` agent is the only directly accessible agent — it receives all user requests and delegates to sub-agents via `sessions_spawn`. The `cursor-agent` serves as a **senior lead** that can both execute complex tasks and direct junior agents.
 
 | Agent | Tier | Role | Workspace |
 |---|---|---|---|
@@ -102,6 +102,9 @@ OpenClaw runs six agents in a two-tier orchestrator pattern. The `homelab-admin`
 | `software-engineer` | Junior | Code development, testing | `/data/workspaces/software-engineer` |
 | `security-analyst` | Junior | Security audits, hardening | `/data/workspaces/security-analyst` |
 | `qa-tester` | Junior | Deployment validation, service health testing, regression checks | `/data/workspaces/qa-tester` |
+| `deutsch-tutor` | Specialist | AI German language tutor — spaced repetition, grammar, conversation | `/data/workspaces/deutsch-tutor` |
+| `english-tutor` | Specialist | AI IELTS 8.0 coach — grammar precision, academic vocabulary, essay feedback, speaking simulation | `/data/workspaces/english-tutor` |
+| `daily-routine` | Specialist | Proactive health & schedule coach — morning briefing, meal reminders, training sessions, hydration, wind-down | `/data/workspaces/daily-routine` |
 
 Every agent has an explicit object-form `model` with `{ primary, fallbacks }` in the configmap:
 

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -28,7 +28,7 @@ flowchart TD
     end
 
     subgraph infisical["Infisical (homelab / prod)"]
-        InfisicalSecrets["OPENCLAW_GATEWAY_TOKEN\nOPENROUTER_API_KEY\nGEMINI_API_KEY\nGITHUB_TOKEN\nDISCORD_BOT_TOKEN\nDISCORD_WEBHOOK_DEUTSCH\nDISCORD_WEBHOOK_ENGLISH\nDISCORD_WEBHOOK_ALERTS\nCURSOR_API_KEY"]
+        InfisicalSecrets["OPENCLAW_GATEWAY_TOKEN\nOPENROUTER_API_KEY\nGEMINI_API_KEY\nGITHUB_TOKEN\nDISCORD_BOT_TOKEN\nDISCORD_WEBHOOK_DEUTSCH\nDISCORD_WEBHOOK_ENGLISH\nDISCORD_WEBHOOK_DAILY\nDISCORD_WEBHOOK_ALERTS\nCURSOR_API_KEY"]
     end
 
     subgraph providers["AI Model Providers"]
@@ -235,6 +235,7 @@ Add the following secrets to Infisical under **homelab / prod**:
 | `DISCORD_BOT_TOKEN` | From [Discord Developer Portal](https://discord.com/developers/applications) → Bot → Reset Token | Yes (for Discord chat channel) |
 | `DISCORD_WEBHOOK_DEUTSCH` | From Discord `#deutsch` channel → Integrations → Webhooks | Yes (for German learning reminders + progress updates) |
 | `DISCORD_WEBHOOK_ENGLISH` | From Discord `#english` channel → Integrations → Webhooks | Yes (for IELTS learning reminders + progress updates) |
+| `DISCORD_WEBHOOK_DAILY` | From Discord `#daily-briefing` channel → Integrations → Webhooks | Yes (for daily routine reminders + schedule updates) |
 | `DISCORD_WEBHOOK_ALERTS` | From Discord `#alerts` channel → Integrations → Webhooks | Yes (for cluster health alerts + incident notifications) |
 | `CURSOR_API_KEY` | From Cursor account settings (API key for headless CLI auth) | Yes (for cursor-agent code generation) |
 
@@ -394,6 +395,7 @@ flowchart TD
 | `#general` | Full homelab admin — cluster ops, GitOps, troubleshooting, general chat | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `weather` | — |
 | `#deutsch` | AI-powered German language tutor — spaced repetition drills, grammar lessons, conversation practice, writing exercises | `deutsch-tutor`, `discord` | `DISCORD_WEBHOOK_DEUTSCH` |
 | `#english` | AI-powered IELTS 8.0 coach — grammar precision, academic vocabulary, essay feedback, speaking simulation | `english-tutor`, `discord` | `DISCORD_WEBHOOK_ENGLISH` |
+| `#daily-briefing` | Proactive health & schedule coach — morning briefing, meal reminders, training sessions, hydration, wind-down | `daily-routine`, `weather`, `discord` | `DISCORD_WEBHOOK_DAILY` |
 | `#alerts` | Cluster health — incident alerts, pod failures, ArgoCD sync issues | `homelab-admin`, `incident-response` | `DISCORD_WEBHOOK_ALERTS` |
 
 Each channel has a system prompt that constrains the agent's behavior to the channel's purpose. The `groupPolicy` is set to `allowlist` so the bot only responds in explicitly configured channels. The `#deutsch` channel routes to the dedicated `deutsch-tutor` agent instead of `homelab-admin`.
@@ -736,7 +738,7 @@ The `openclaw.json` config (in `configmap.yaml`) contains these key settings:
 
 ## Multi-Agent & Skills Architecture
 
-OpenClaw runs eight agents in a multi-tier hierarchy: a `homelab-admin` orchestrator, a `cursor-agent` senior lead (with PR review authority and sub-agent spawning), and four junior specialist agents.
+OpenClaw runs nine agents in total: a `homelab-admin` orchestrator, a `cursor-agent` senior lead (with PR review authority and sub-agent spawning), four junior specialist agents, and three additional specialist agents for domain-specific tasks.
 
 ```mermaid
 flowchart TD
@@ -791,7 +793,7 @@ Each agent has a `skills` allowlist in the configmap that restricts which skills
 
 | Agent | Tier | Assigned Skills |
 |---|---|---|
-| `homelab-admin` | Orchestrator | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `weather`, `deutsch-tutor`, `english-tutor` |
+| `homelab-admin` | Orchestrator | `homelab-admin`, `gitops`, `secret-management`, `incident-response`, `weather`, `deutsch-tutor`, `english-tutor`, `daily-routine` |
 | `cursor-agent` | Senior lead | `cursor-agent`, `gitops`, `software-engineer`, `security-analyst`, `qa-tester` |
 | `devops-sre` | Junior | `devops-sre`, `gitops`, `secret-management`, `incident-response` |
 | `software-engineer` | Junior | `software-engineer`, `gitops` |
@@ -810,6 +812,7 @@ Each agent has a `skills` allowlist in the configmap that restricts which skills
 | `qa-tester` | Junior | Deployment validation, service health testing, regression checks | `/data/workspaces/qa-tester` |
 | `deutsch-tutor` | Specialist | AI German language tutor — spaced repetition, grammar, conversation | `/data/workspaces/deutsch-tutor` |
 | `english-tutor` | Specialist | AI IELTS 8.0 coach — grammar precision, academic vocabulary, essay feedback, speaking practice | `/data/workspaces/english-tutor` |
+| `daily-routine` | Specialist | Proactive health & schedule coach — morning briefing, meal reminders, training sessions, hydration, wind-down | `/data/workspaces/daily-routine` |
 
 Every agent has an explicit object-form `model` in the configmap (see [Model config convention](#model-config-convention-important)):
 


### PR DESCRIPTION
$This documentation update brings the OpenClaw and AI Agents docs in line with the current cluster state:\n\n- Add **Daily Routine Coach** agent and #daily-briefing Discord channel\n- Update OpenClaw README with new webhook secret, channel table, agent table, and skills\n- Update AI Agents doc to reflect nine total agents (six core + three specialists)\n- Correct minor inconsistencies (agent count, skills)\n\nThese changes are documentation-only; no infrastructure modifications.\n