### PR TITLE
fix: set default userTimezone to Asia/Ho_Chi_Minh to correct daily briefing date

### DIFF
--- a/k8s/apps/openclaw/configmap.yaml
+++ b/k8s/apps/openclaw/configmap.yaml
@@ -117,7 +117,8 @@ data:
             "maxConcurrent": 4,
             "maxChildrenPerAgent": 3,
             "archiveAfterMinutes": 120
-          }
+          },
+          "userTimezone": "Asia/Ho_Chi_Minh"
         }
       },
       "channels": {


### PR DESCRIPTION
## Summary
- Add  to  in OpenClaw ConfigMap
- This ensures daily briefing (and all agents) display times in the user's local timezone (ICT, UTC+7) instead of UTC

## Test plan
- [ ] PR passes pre-merge validation (YAML syntax, etc.)
- [ ] ArgoCD syncs the openclaw-config ConfigMap
- [ ] Next daily briefing (07:00 ICT) shows the correct local date
- [ ] No other services are impacted

## Closes
Closes #124

---
Agent: homelab-admin | OpenClaw Homelab