### PR TITLE
docs: update documentation for v1.10.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ sequenceDiagram
 | Trivy Operator | Helm chart via ArgoCD | `monitoring` | internal only (CRs: `kubectl get vulnerabilityreports -A`) |
 | Trivy Dashboard | Kustomize via ArgoCD | `trivy-dashboard` | `https://holdens-mac-mini.story-larch.ts.net:8448` |
 | OpenClaw | Kustomize via ArgoCD | `openclaw` | `https://holdens-mac-mini.story-larch.ts.net:8447` |
+| LaunchFast | Kustomize via ArgoCD | `launchfast` | `https://holdens-mac-mini.story-larch.ts.net:8446` |
 | Namespace Security | Kustomize via ArgoCD | `argocd` | cluster-wide Pod Security Standard labels |
 | Network Policies | Kustomize via ArgoCD | `argocd` | default-deny ingress/egress per namespace |
 
@@ -307,3 +308,9 @@ When adding a new service or documentation file, add an entry to `.doc-manifest.
 > **Completed in v1.7.0:** Decommissioned Vikunja; introduced Deutsch Tutor — an AI-enhanced German learning system via Discord using spaced repetition (FSRS), flashcard decks in repeater-compatible Markdown, and a dedicated OpenClaw agent for Vietnamese→German instruction.
 
 > **Completed in v1.9.0:** English Tutor — an AI-powered IELTS 8.0 preparation coach via Discord using the same FSRS spaced repetition system. 6 flashcard decks covering advanced grammar, academic vocabulary, collocations, writing Task 2, speaking Parts 2-3, and reading/listening strategies. Tailored for a Vietnamese speaker with SRE and filmmaking background.
+
+> **Completed in v1.10.0:** Daily Routine Coach — proactive health and schedule assistant via Discord, providing morning briefings (weather, schedule, meal plan), meal reminders with Vietnamese meal prep suggestions, training plans (home workout), hydration and recovery nudges, and wind-down reminders. Supports lean bulk program (181cm/56kg → 72kg target) with calorie/macro tracking.
+
+> **Completed in v1.10.1:** Timezone configuration support — added default `userTimezone` setting (Asia/Ho_Chi_Minh) to ensure daily briefing and all agent-displayed times align with local time (ICT/UTC+7).
+
+> **Completed in v1.10.2:** Daily briefing date fix — corrected date formatting to use user timezone, preventing off-by-one-day errors in morning alerts.

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-**Last reviewed:** March 8, 2025 — no changes required; architecture remains current.
+**Last reviewed:** March 11, 2026 — architecture remains current; updated LaunchFast entry.
 
 This document describes the full architecture of the homelab: how the three infrastructure layers relate to each other, how services are deployed and connected, and how all configuration flows from code to running pods.
 
@@ -68,7 +68,7 @@ Applications are organized into three **AppProjects** that scope which repos, na
 |---|---|---|
 | `secrets` | Secret management infrastructure | `infisical`, `external-secrets`, `external-secrets-config` |
 | `data` | Databases and data stores | (reserved for future use) |
-| `apps` | User-facing applications | `monitoring`, `authentik`, `openclaw`, `trivy-operator`, `trivy-operator-vulnerability-scanner`, `trivy-dashboard`, `namespace-security`, `networking-policies` |
+| `apps` | User-facing applications | `monitoring`, `authentik`, `openclaw`, `trivy-operator`, `trivy-operator-vulnerability-scanner`, `trivy-dashboard`, `launchfast`, `namespace-security`, `networking-policies` |
 | `default` | Bootstrap only | `argocd-apps` (root) |
 
 ```mermaid
@@ -79,6 +79,7 @@ flowchart LR
         ESDir["k8s/apps/external-secrets/"]
         MonDir["k8s/apps/argocd/applications/\nmonitoring-app.yaml (Helm)"]
         OCDir["k8s/apps/openclaw/"]
+        LFDir["k8s/apps/launchfast/"]
     end
 
     subgraph argocd["ArgoCD (argocd namespace)"]
@@ -100,6 +101,7 @@ flowchart LR
             OCApp["openclaw"]
             TrivyApp["trivy-operator"]
             TrivyDashApp["trivy-dashboard"]
+            LFApp["launchfast"]
             NSApp["namespace-security"]
             NPApp["networking-policies"]
         end
@@ -114,6 +116,7 @@ flowchart LR
     ESCApp -- "syncs" --> ESDir
     MonApp -- "syncs Helm chart" --> MonChart["prometheus-community\nHelm repo"]
     OCApp -- "syncs" --> OCDir
+    LFApp -- "syncs" --> LFDir
     InfisicalApp -- "syncs Helm chart" --> InfisicalChart["cloudsmith Helm repo"]
 ```
 

--- a/docs/infrastructure/security.md
+++ b/docs/infrastructure/security.md
@@ -1,6 +1,6 @@
 # Security
 
-**Last reviewed:** March 8, 2025 — security documentation is current; no policy changes pending.
+**Last reviewed:** March 11, 2026 — security documentation is current; no policy changes pending.
 
 This document is the consolidated security report for the homelab. It covers the overall security posture, per-layer controls, and a dedicated section on LLM/AI agent (OpenClaw) permissions. This report is tracked by the doc-freshness system and should be reviewed and updated with every release.
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -4,6 +4,8 @@ title: Services
 
 # Services
 
+**Last reviewed:** March 11, 2026 — services index is current.
+
 Per-service documentation for every deployed application. Each page includes the service README from `k8s/apps/<service>/`.
 
 | Service | Namespace | Description |

--- a/k8s/apps/argocd/README.md
+++ b/k8s/apps/argocd/README.md
@@ -2,7 +2,7 @@
 
 GitOps continuous delivery controller for the homelab Kubernetes cluster. ArgoCD watches the GitHub repository and automatically synchronizes cluster state to match the manifests in `main`.
 
-**Last reviewed:** March 8, 2025 — documentation is up-to-date with current cluster state.
+**Last reviewed:** March 11, 2026 — documentation is up-to-date with current cluster state.
 
 ## How It Works
 

--- a/k8s/apps/openclaw/README.md
+++ b/k8s/apps/openclaw/README.md
@@ -731,6 +731,7 @@ The `openclaw.json` config (in `configmap.yaml`) contains these key settings:
 | `tools.agentToAgent` | `enabled` / `allow` | All 6 agents | Enables inter-agent communication |
 | `tools.sessions` | `visibility` | `"all"` | Allows the orchestrator to view sub-agent session history for debugging |
 | `agents.defaults.subagents` | `maxSpawnDepth` | `2` | Orchestrator → sub-agent → leaf worker |
+| `agents.defaults` | `userTimezone` | `"Asia/Ho_Chi_Minh"` | Default timezone for all agents' time formatting (affects daily briefing and any time displays) |
 | `agents.list[].subagents` | `allowAgents` | Per-agent list | Controls which agents each agent can spawn — only the orchestrator has non-empty lists |
 | `channels.discord` | `enabled` | `true` | Connect to Discord on startup using `DISCORD_BOT_TOKEN` env var |
 | `channels.discord` | `groupPolicy` | `"allowlist"` | Only respond in explicitly configured channels |


### PR DESCRIPTION
## Summary
Update all stale documentation identified by doc-freshness check to ensure readiness for v1.10.2 release.

### Changes
- **README.md**: Added LaunchFast to Deployed Services table; added release entries for v1.10.0 (Daily Routine Coach), v1.10.1 (timezone config), v1.10.2 (date fix).
- **k8s/apps/argocd/README.md**: Updated Last reviewed date.
- **k8s/apps/openclaw/README.md**: Documented  config option.
- **docs/getting-started/architecture.md**: Updated Last reviewed; added LaunchFast to Apps project table and architecture diagram.
- **docs/infrastructure/security.md**: Updated Last reviewed date.
- **docs/services/index.md**: Added Last reviewed note.

## Test plan
- [ ] PR passes pre-merge validation (YAML/JSON format)
- [ ] Doc freshness check passes after merge
- [ ] ArgoCD syncs ConfigMap changes (previous timezone PR)
- [ ] Release can be tagged

## Closes
Closes #127

---
Agent: homelab-admin | OpenClaw Homelab