### PR TITLE
feat(ops): nightly shutdown 23:59, startup 04:59 (v1.11.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,3 +314,5 @@ When adding a new service or documentation file, add an entry to `.doc-manifest.
 > **Completed in v1.10.1:** Timezone configuration support — added default `userTimezone` setting (Asia/Ho_Chi_Minh) to ensure daily briefing and all agent-displayed times align with local time (ICT/UTC+7).
 
 > **Completed in v1.10.2:** Daily briefing date fix — corrected date formatting to use user timezone, preventing off-by-one-day errors in morning alerts.
+
+> **Completed in v1.11.0:** NetworkPolicy egress and ArgoCD project alignment; Cilium reverted for OrbStack CNI compatibility; nightly OrbStack shutdown/startup window set to 23:59 / 04:59 (host launchd); documentation updated.

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -172,7 +172,7 @@ For the full secret management reference, see [docs/secret-management.md](../inf
 
 Some operational tasks are managed outside of Kubernetes using macOS launchd:
 
-- **Nightly shutdown/startup**: The OrbStack Kubernetes cluster automatically stops at 23:30 and starts at 06:30 daily to save power and reduce host wear. This is implemented with wrapper scripts (`scripts/orb-stop.sh`, `scripts/orb-start.sh`) and launchd plists (`scripts/com.homelab.orbstop.plist`, `scripts/com.homelab.orbstart.plist`). See [Nightly Shutdown Documentation](../operations/nightly-shutdown.md) for full details.
+- **Nightly shutdown/startup**: The OrbStack Kubernetes cluster automatically stops at 23:59 and starts at 04:59 daily to save power and reduce host wear. This is implemented with wrapper scripts (`scripts/orb-stop.sh`, `scripts/orb-start.sh`) and launchd plists (`scripts/com.homelab.orbstop.plist`, `scripts/com.homelab.orbstart.plist`). See [Nightly Shutdown Documentation](../operations/nightly-shutdown.md) for full details.
 
 These components run on the host macOS and are not managed by ArgoCD (since ArgoCD itself runs inside the cluster that gets shut down).
 

--- a/docs/operations/nightly-shutdown.md
+++ b/docs/operations/nightly-shutdown.md
@@ -4,7 +4,7 @@ This page documents the automated nightly shutdown and startup of the OrbStack K
 
 ## Overview
 
-To save power and reduce wear on the host Mac mini M4, the homelab cluster automatically stops every night at 11:30 PM and restarts at 6:30 AM. This is implemented as host-level automation using macOS launchd, not as a Kubernetes resource.
+To save power and reduce wear on the host Mac mini M4, the homelab cluster automatically stops every night at 11:59 PM and restarts at 4:59 AM. This is implemented as host-level automation using macOS launchd, not as a Kubernetes resource.
 
 **Note:** This is a temporary/quick solution. Future improvements may use more robust approaches.
 
@@ -60,7 +60,7 @@ Two launchd plist files are provided:
 
 ### `com.homelab.orbstop.plist`
 
-Runs daily at **23:30** (11:30 PM).
+Runs daily at **23:59** (11:59 PM).
 
 ```xml
 <key>StartCalendarInterval</key>
@@ -68,21 +68,21 @@ Runs daily at **23:30** (11:30 PM).
     <key>Hour</key>
     <integer>23</integer>
     <key>Minute</key>
-    <integer>30</integer>
+    <integer>59</integer>
 </dict>
 ```
 
 ### `com.homelab.orbstart.plist`
 
-Runs daily at **06:30** (6:30 AM).
+Runs daily at **04:59** (4:59 AM).
 
 ```xml
 <key>StartCalendarInterval</key>
 <dict>
     <key>Hour</key>
-    <integer>6</integer>
+    <integer>4</integer>
     <key>Minute</key>
-    <integer>30</integer>
+    <integer>59</integer>
 </dict>
 ```
 
@@ -121,7 +121,7 @@ To change the schedule, edit the `<dict>` section in each plist:
     <key>Hour</key>
     <integer>23</integer>   <!-- Change hour (0-23) -->
     <key>Minute</key>
-    <integer>30</integer>   <!-- Change minute (0-59) -->
+    <integer>59</integer>   <!-- Change minute (0-59) -->
 </dict>
 ```
 
@@ -155,9 +155,9 @@ Launchd's `StartCalendarInterval` triggers when the Mac wakes from sleep if the 
 
 ### Missed Jobs
 
-- **Shutdown missed** (e.g., Mac was off at 23:30): The shutdown will simply not occur that night. The cluster will remain running overnight. The next night's shutdown at 23:30 will proceed normally.
+- **Shutdown missed** (e.g., Mac was off at 23:59): The shutdown will simply not occur that night. The cluster will remain running overnight. The next night's shutdown at 23:59 will proceed normally.
 
-- **Startup missed** (e.g., Mac was off at 06:30): The startup will not occur automatically. The cluster will remain stopped. You must start it manually with `orb start k8s` or wait until the next morning's scheduled startup.
+- **Startup missed** (e.g., Mac was off at 04:59): The startup will not occur automatically. The cluster will remain stopped. You must start it manually with `orb start k8s` or wait until the next scheduled startup.
 
 ### Idempotency
 

--- a/release-notes-v1.11.0.md
+++ b/release-notes-v1.11.0.md
@@ -1,120 +1,38 @@
 ### Summary
 
-Release v1.11.0 introduces network stack modernization with eBPF-based Cilium CNI, delivering true NetworkPolicy enforcement and built-in observability. This release also closes critical network policy gaps that were previously non-functional due to Flannel's limitations.
+Release v1.11.0 captures merged work since **v1.10.3**: NetworkPolicy egress and ArgoCD project alignment, an attempted Cilium CNI rollout that was **reverted** to stay compatible with OrbStack’s supported CNI, follow-up documentation, and a new default **nightly OrbStack stop/start window** on the Mac mini host (**23:59** / **04:59** local time).
 
 **Highlights:**
-- **Cilium** replaces Flannel for policy enforcement and high-performance networking
-- **Hubble** provides real-time network flow visibility and service map
-- **Authentik** now has internet egress for OIDC discovery, avatar downloads, and upstream providers
-- **Prometheus** can now scrape kubelet metrics (10250) for node-level metrics
-- **ArgoCD projects** cleaned up: networking-policies and namespace-security now use `apps` project
 
----
-
-## New Features
-
-### feat(cni): install Cilium eBPF dataplane
-
-- Switched from Flannel to Cilium for enforced NetworkPolicies
-- Enabled eBPF dataplane for lower latency and CPU overhead
-- Hubble observability layer installed (optional UI)
-- kube-proxy remains enabled initially for compatibility; can switch to `strict` replacement later
-
-Relevant: #130
-
-### feat(network): monitoring cross-namespace scrape rules
-
-- Added `allow-egress-kubelet` policy in `monitoring` namespace (ports 10250, 9153)
-  - Port 10250: kubelet metrics
-  - Port 9153: coredns metrics
-- Enables Prometheus to scrape core infrastructure from `kube-system`
-- Completes cross-namespace scrape requirements referenced in #38
-
-Part of PR #129
-
-### feat(network): authentik internet egress
-
-- Added `allow-egress-internet` policy in `authentik` namespace
-- Fixes OIDC discovery, avatar downloads, and external authentication providers
-- Authentik can now reach external identity providers over HTTPS
-
-Part of PR #129
+- **Nightly shutdown/startup** — launchd schedule updated in-repo (`scripts/com.homelab.*.plist`) with matching docs; reload LaunchAgents on the host after pull
+- **Network policies** — additional egress rules (e.g. monitoring → kubelet/coredns, authentik → internet) and migration of apps to the `apps` ArgoCD project (#129)
+- **CNI** — Cilium was tried (#131) then **removed** (#133) because OrbStack requires its bundled CNI; docs now describe Flannel limitations and policy expectations
 
 ---
 
 ## Improvements
 
-### chore(argocd): migrate networking-policies and namespace-security to apps project
+### feat(ops): nightly shutdown 23:59, startup 04:59
 
-- Both apps moved from `default` to `apps` for consistency
-- Expanded `apps` project destinations to include `argocd`, `external-secrets`, `infisical`
-- Enforces proper project isolation and alignment with conventions
+- Shutdown **23:30 → 23:59**; startup **06:30 → 04:59**
+- Updated plist templates, wrapper script comments, and [Nightly Shutdown](docs/operations/nightly-shutdown.md) / [Architecture](docs/getting-started/architecture.md)
 
-Part of PR #129
+### chore(network): policy gaps, ArgoCD project cleanup (#129)
+
+- `allow-egress-kubelet` for monitoring; `allow-egress-internet` for authentik; related fixes
+- networking-policies and namespace-security use `apps` project; expanded `apps` destinations where needed
+
+### fix(cni): remove Cilium for OrbStack compatibility (#133)
+
+- Cilium Application and related values removed; cluster remains on OrbStack’s default CNI
+- Documentation updated to reflect current networking posture
 
 ---
 
 ## Technical Notes
 
-### NetworkPolicy Gap Closure
-
-Previously, default-deny policies had no effect because Flannel doesn't enforce them. With Cilium, these policies are now active:
-
-- default-deny-all (all app namespaces)
-- allow-same-namespace
-- allow-dns
-- allow-tailscale-ingress
-- allow-egress-apiserver
-- allow-egress-internet (where defined)
-- allow-egress-kubelet (monitoring)
-- cross-namespace allows (external-secrets ↔ infisical)
-
-### Cilium Configuration
-
-- **Version:** 1.17.x
-- **Mode:** `kubeProxyReplacement=disabled` (coexist with kube-proxy)
-- **eBPF:** Enabled with masquerade
-- **Hubble:** Enabled with UI at `http://<tailscale-ip>:12000` (configurable)
-
-### Upgrade Path
-
-This release is a **minor** version bump due to the CNI change, which is backward-compatible at the application level (no API changes). Future releases may enable kube-proxy replacement.
-
----
-
-## Migration Guide (if upgrading from v1.10.x)
-
-**Important:** This release changes the cluster's CNI. Follow these steps carefully.
-
-1. **Backup** your current manifests and `k8s/` repository.
-2. Merge PR #129 into your `main` branch and let ArgoCD sync.
-3. Deploy Cilium via ArgoCD (new `cilium` app in `apps` project). This will:
-   - Disable Flannel DaemonSet (k3s default)
-   - Install Cilium operator and agents
-   - Reconfigure node networking
-4. **Monitor** pod readiness: `kubectl get pods -A -w`
-5. Verify service connectivity:
-   - Tailscale serve endpoints
-   - NodePort services (Grafana, Authentik, etc.)
-   - ArgoCD UI
-6. Confirm Hubble UI is accessible.
-7. Once stable, you may optionally set `kubeProxyReplacement=strict` to remove kube-proxy dependency.
-
-**Rollback:** If issues arise, disable Cilium app and re-enable Flannel (manual steps documented in `docs/networking/cni-migration.md`).
-
----
-
-## Component Versions
-
-| Component | Previous | Current |
-|-----------|----------|---------|
-| CNI | Flannel (k3s) | Cilium 1.17.x |
-| NetworkPolicy enforcement | No | Yes (via eBPF) |
-| Observability | - | Hubble UI |
-| Authentik | 2025.12.4 | 2025.12.4 (unchanged) |
-| Prometheus | kube-prometheus-stack 82.1.0 | unchanged |
-| Infisical | 1.7.2 | unchanged |
-| OpenClaw | e024f190 | unchanged |
+- **NetworkPolicy** on Flannel does not enforce L3/L4 isolation like a full CNI policy engine; default-deny and allow rules document intent and future portability
+- **Host automation** is not applied by ArgoCD — after upgrading, copy plists to `~/Library/LaunchAgents/` and reload jobs per [nightly-shutdown.md](docs/operations/nightly-shutdown.md)
 
 ---
 
@@ -124,6 +42,5 @@ This release is a **minor** version bump due to the CNI change, which is backwar
 
 ---
 
-**Release date:** 2026-03-XX  
-**Tag:** v1.11.0  
-**GitHub milestone:** [v1.11.0](https://github.com/holdennguyen/homelab/milestone/11)
+**Release date:** 2026-03-30  
+**Tag:** v1.11.0

--- a/scripts/com.homelab.orbstart.plist
+++ b/scripts/com.homelab.orbstart.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <!-- OrbStack Kubernetes Nightly Startup -->
-    <!-- Starts the Kubernetes cluster at 06:30 (6:30 AM) daily -->
+    <!-- Starts the Kubernetes cluster at 04:59 (4:59 AM) daily -->
     <!-- Install with: cp com.homelab.orbstart.plist ~/Library/LaunchAgents/ && launchctl load ~/Library/LaunchAgents/com.homelab.orbstart.plist -->
 
     <key>Label</key>
@@ -21,9 +21,9 @@
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>
-        <integer>6</integer>
+        <integer>4</integer>
         <key>Minute</key>
-        <integer>30</integer>
+        <integer>59</integer>
     </dict>
 
     <!-- Standard output and error go to log files -->

--- a/scripts/com.homelab.orbstop.plist
+++ b/scripts/com.homelab.orbstop.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <!-- OrbStack Kubernetes Nightly Shutdown -->
-    <!-- Stops the Kubernetes cluster at 23:30 (11:30 PM) daily -->
+    <!-- Stops the Kubernetes cluster at 23:59 (11:59 PM) daily -->
     <!-- Install with: cp com.homelab.orbstop.plist ~/Library/LaunchAgents/ && launchctl load ~/Library/LaunchAgents/com.homelab.orbstop.plist -->
 
     <key>Label</key>
@@ -23,7 +23,7 @@
         <key>Hour</key>
         <integer>23</integer>
         <key>Minute</key>
-        <integer>30</integer>
+        <integer>59</integer>
     </dict>
 
     <!-- Standard output and error go to log files -->

--- a/scripts/orb-start.sh
+++ b/scripts/orb-start.sh
@@ -3,7 +3,7 @@
 # OrbStack Kubernetes nightly startup script
 # Starts the OrbStack Kubernetes cluster and waits for health
 #
-# This script is intended to be run via macOS launchd at 06:30 daily.
+# This script is intended to be run via macOS launchd at 04:59 daily.
 # Launchd redirects stdout/stderr to ~/Library/Logs/homelab/startup.log,
 # so this script writes to stdout only (no tee).
 #

--- a/scripts/orb-stop.sh
+++ b/scripts/orb-stop.sh
@@ -3,7 +3,7 @@
 # OrbStack Kubernetes nightly shutdown script
 # Safely stops the OrbStack Kubernetes cluster with logging and state checks
 #
-# This script is intended to be run via macOS launchd at 23:30 daily.
+# This script is intended to be run via macOS launchd at 23:59 daily.
 # Launchd redirects stdout/stderr to ~/Library/Logs/homelab/shutdown.log,
 # so this script writes to stdout only (no tee).
 #


### PR DESCRIPTION
## Summary

Shifts the Mac host launchd schedule for OrbStack k8s: **stop 23:59**, **start 04:59** (was 23:30 / 06:30).

## Changes

- `com.homelab.orbstop.plist` / `com.homelab.orbstart.plist` — `StartCalendarInterval`
- `orb-stop.sh` / `orb-start.sh` — header comments
- `docs/operations/nightly-shutdown.md`, `docs/getting-started/architecture.md`
- `release-notes-v1.11.0.md` — accurate notes for tagging **v1.11.0** (replaces obsolete Cilium-only draft); README **Completed in v1.11.0** line

## Post-merge

Tag **v1.11.0** and publish GitHub Release with `release-notes-v1.11.0.md`.

**Host:** Copy updated plists to `~/Library/LaunchAgents/` and unload/reload each job.

Made with [Cursor](https://cursor.com)